### PR TITLE
Enhance docstrings for signal models

### DIFF
--- a/paleobeasts/signal_models/box_model.py
+++ b/paleobeasts/signal_models/box_model.py
@@ -122,28 +122,58 @@ class BoxModelContext:
 class BoxModelSpec:
     """Declarative specification for simple ODE box models.
 
-    A ``BoxModelSpec`` stores state names, parameter defaults, optional inputs,
-    diagnostics, and either:
+    A ``BoxModelSpec`` stores state names, parameter defaults, optional
+    inputs, diagnostics, and either:
 
-    - explicit callable tendencies, or
-    - an automatic box network assembled from volumes, reciprocal exchange, and
-      directed transport terms
+    - explicit callable tendencies registered via
+      :meth:`register_tendency` / :meth:`register_relations`, or
+    - an automatic box network assembled from volumes, reciprocal exchange,
+      and directed transport terms
+
+    Parameters
+    ----------
+    name : str
+        Model name used as the default ``var_name`` of the produced
+        ``GenericBoxModel``.
+
+    Notes
+    -----
+    Call :meth:`validate` (or :meth:`make_boxmodel`) before integrating.
+    Validation checks that every state variable has a tendency relation
+    (explicit mode) or a registered volume (automatic mode).
+
+    See also
+    --------
+    GenericBoxModel : The ``PBModel`` subclass produced by :meth:`make_boxmodel`.
+    BoxModelContext : Evaluation context passed to callable tendencies.
 
     Examples
     --------
     Minimal explicit one-box relaxation model:
 
-    >>> spec = BoxModelSpec("relaxation")
-    >>> spec.register_state_variables(["x"])
-    >>> spec.register_parameters(tau=10.0, x_eq=1.0)
-    >>> spec.register_tendency("x", lambda ctx: (ctx.param("x_eq") - ctx["x"]) / ctx.param("tau"))
+    .. code-block:: python
+
+        import paleobeasts as pb
+        from paleobeasts.signal_models.box_model import BoxModelSpec
+
+        spec = BoxModelSpec("relaxation")
+        spec.register_state_variables(["x"])
+        spec.register_parameters(tau=10.0, x_eq=1.0)
+        spec.register_tendency(
+            "x", lambda ctx: (ctx.param("x_eq") - ctx["x"]) / ctx.param("tau")
+        )
+        model = spec.make_boxmodel()
+        output = model.integrate(t_span=(0, 100), y0=[0.0], method='RK45')
 
     Automatic two-box exchange model:
 
-    >>> spec = BoxModelSpec("exchange")
-    >>> spec.register_state_variables(["A", "S"])
-    >>> spec.register_box_volumes(A=1.0, S=50.0)
-    >>> spec.register_exchange("A", "S", 0.2)
+    .. code-block:: python
+
+        spec = BoxModelSpec("exchange")
+        spec.register_state_variables(["A", "S"])
+        spec.register_box_volumes(A=1.0, S=50.0)
+        spec.register_exchange("A", "S", 0.2)
+        model = spec.make_boxmodel()
     """
 
     def __init__(self, name):
@@ -355,12 +385,26 @@ class BoxModelSpec:
 
 
 class GenericBoxModel(PBModel):
-    """PBModel backed by a :class:`BoxModelSpec`.
+    """``PBModel`` subclass produced by :class:`BoxModelSpec`.
 
-    Users will usually construct this via ``BoxModelSpec.make_boxmodel()``.
-    The resulting model behaves like any other ``PBModel`` subclass: it can be
-    integrated with ``integrate(...)``, exported to Pyleoclim, and post-process
-    diagnostics from solved history.
+    Users construct this via :meth:`BoxModelSpec.make_boxmodel` rather than
+    instantiating it directly.  The resulting model integrates with
+    ``model.integrate(...)``, exports to Pyleoclim via ``output.to_pyleo()``,
+    and computes diagnostics from solved history via
+    ``populate_diagnostics_from_history``.
+
+    Parameters
+    ----------
+    spec : BoxModelSpec
+        The validated specification object.
+    forcing : pb.core.Forcing or None
+        Optional external forcing passed through to registered input
+        channels.  Default ``None``.
+    var_name : str or None
+        Override for the model name.  Defaults to ``spec.name``.
+    **kwargs
+        Additional parameter overrides applied on top of
+        ``spec.parameter_defaults``.
     """
 
     def __init__(self, spec, forcing=None, var_name=None, *args, **kwargs):

--- a/paleobeasts/signal_models/daisyworld.py
+++ b/paleobeasts/signal_models/daisyworld.py
@@ -6,12 +6,75 @@ from ..core.pbmodel import PBModel
 class Daisyworld(PBModel):
     """Minimal 0D Daisyworld model with black/white daisy coverage and temperature.
 
-    State variables are:
-    - ``Aw``: white daisy fractional coverage
-    - ``Ab``: black daisy fractional coverage
-    - ``T``: planetary mean temperature (K)
+    The model couples daisy population dynamics to a zero-dimensional energy
+    balance.  Local temperatures depend on albedo contrasts via:
 
-    Parameters can be constants, callables, or ``pb.Forcing`` objects.
+        T_w = T + q * (A_planet - alpha_w)   # white daisy local temperature
+        T_b = T + q * (A_planet - alpha_b)   # black daisy local temperature
+
+    and the prognostic equations are:
+
+        dAw/dt = Aw * (A_bare * beta_w - gamma)
+        dAb/dt = Ab * (A_bare * beta_b - gamma)
+        C * dT/dt = S0*L/4 * (1 - A_planet) - sigma * T^4
+
+    Parameters
+    ----------
+    forcing : pb.core.Forcing or None
+        Optional luminosity perturbation added to ``L``.  Default ``None``.
+    var_name : str
+        Label for the model output.  Default ``'daisyworld'``.
+    alpha_w : float or callable or pb.core.Forcing
+        White daisy albedo.  Default 0.75.
+    alpha_b : float or callable or pb.core.Forcing
+        Black daisy albedo.  Default 0.25.
+    alpha_g : float or callable or pb.core.Forcing
+        Bare-ground albedo.  Default 0.5.
+    gamma : float or callable or pb.core.Forcing
+        Daisy death rate (fraction per unit time).  Default 0.3.
+    q : float or callable or pb.core.Forcing
+        Local temperature sensitivity to albedo contrast (K).  Default 20.0.
+    T_opt : float or callable or pb.core.Forcing
+        Optimal daisy growth temperature (K).  Default 295.0.
+    beta_width : float or callable or pb.core.Forcing
+        Parabolic growth-rate width parameter.  Default 0.003265.
+    S0 : float or callable or pb.core.Forcing
+        Solar constant (W m\ :sup:`-2`).  Default 1365.0.
+    L : float or callable or pb.core.Forcing
+        Normalized stellar luminosity (1.0 = present Sun).  Default 1.0.
+    C : float or callable or pb.core.Forcing
+        Planetary heat capacity (effective, in model units).  Default 10.0.
+    sigma : float or callable or pb.core.Forcing
+        Stefan-Boltzmann constant (W m\ :sup:`-2` K\ :sup:`-4`).
+        Default 5.67051196e-8.
+
+    Notes
+    -----
+    State variables are ``Aw``, ``Ab``, ``T`` in that order.
+    Diagnostic variables populated during integration are ``A_planet``,
+    ``A_bare``, ``beta_w``, and ``beta_b``.
+
+    Daisy area fractions are soft-clipped to [0, 1] inside ``dydt`` to
+    avoid unphysical growth; the solver may transiently produce small
+    negative values which are set to zero for tendency calculations.
+
+    References
+    ----------
+    Watson, A. J., & Lovelock, J. E. (1983). Biological homeostasis of the
+    global environment: The parable of Daisyworld. Tellus B, 35(4), 284–289.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import paleobeasts as pb
+        from paleobeasts.signal_models.daisyworld import Daisyworld
+
+        model = Daisyworld(forcing=None, L=0.9)
+        output = model.integrate(
+            t_span=(0, 500), y0=[0.2, 0.2, 295.0], method='RK45'
+        )
+        ts = output.to_pyleo(var_names=['Aw', 'Ab', 'T'])
     """
 
     def __init__(self, forcing=None, var_name='daisyworld', alpha_w=0.75, alpha_b=0.25, alpha_g=0.5,

--- a/paleobeasts/signal_models/enso_recharge.py
+++ b/paleobeasts/signal_models/enso_recharge.py
@@ -8,9 +8,66 @@ from paleobeasts.core.pbmodel import PBModel
 class ENSORechargeOscillator(PBModel):
     """Jin-style ENSO recharge oscillator.
 
-    The implementation follows the lab09 recharge-oscillator worksheet, but
-    uses the Paleobeasts ``dydt(self, t, state)`` convention instead of the
-    worksheet's ``odeint`` state-first convention.
+    Couples the eastern Pacific SST anomaly ``T`` to the thermocline depth
+    anomaly ``h`` via a nonlinear recharge-discharge mechanism:
+
+        dT/dt = R*T + gamma*h - en*(h + b*T)^3 + Af*sin(2*pi*t/Pf)
+        dh/dt = -r*h - alpha*b*T
+
+    where ``b = b0*mu`` and ``R = gamma*b - c``.
+
+    Parameters
+    ----------
+    forcing : pb.core.Forcing or None
+        External forcing added to ``dT/dt``.  If provided it overrides the
+        internal seasonal term ``Af*sin(2*pi*t/Pf)``.  Default ``None``.
+    var_name : str
+        Label for the model output.  Default ``'enso_recharge_oscillator'``.
+    mu : float or callable or pb.core.Forcing
+        Bjerknes coupling coefficient.  Default 0.7.
+    en : float or callable or pb.core.Forcing
+        Nonlinear damping coefficient.  Default 0.0 (linear limit).
+    Af : float or callable or pb.core.Forcing
+        Seasonal forcing amplitude.  Default 0.0.
+    Pf : float or callable or pb.core.Forcing
+        Seasonal forcing period (model time units).  Default 6.0.
+    c : float or callable or pb.core.Forcing
+        Newtonian cooling rate of SST.  Default 1.0.
+    r : float or callable or pb.core.Forcing
+        Thermocline recharge damping rate.  Default 0.25.
+    alpha : float or callable or pb.core.Forcing
+        Wind-stress feedback strength.  Default 0.125.
+    b0 : float or callable or pb.core.Forcing
+        Background thermocline slope sensitivity.  Default 2.5.
+    gamma : float or callable or pb.core.Forcing
+        Thermocline feedback onto SST.  Default 0.75.
+
+    Notes
+    -----
+    The internal time scale is ``tscale = 1/6`` (months to years mapping);
+    this is baked in but does not affect ``t`` directly as the equations are
+    already in the dimensionless form used in the worksheet.
+
+    State variables are ``T`` and ``h`` in that order.  ``Pf`` must be
+    non-zero (raises ``ValueError`` otherwise).
+
+    References
+    ----------
+    Jin, F.-F. (1997). An equatorial ocean recharge paradigm for ENSO.
+    J. Atmos. Sci., 54, 811–829.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import paleobeasts as pb
+        from paleobeasts.signal_models.enso_recharge import ENSORechargeOscillator
+
+        model = ENSORechargeOscillator(forcing=None, mu=0.75, Af=0.5, Pf=6.0)
+        output = model.integrate(
+            t_span=(0, 120), y0=[0.5, 0.0], method='RK45'
+        )
+        ts = output.to_pyleo(var_names=['T', 'h'])
     """
 
     def __init__(

--- a/paleobeasts/signal_models/enso_recharge.py
+++ b/paleobeasts/signal_models/enso_recharge.py
@@ -19,8 +19,10 @@ class ENSORechargeOscillator(PBModel):
     Parameters
     ----------
     forcing : pb.core.Forcing or None
-        External forcing added to ``dT/dt``.  If provided it overrides the
-        internal seasonal term ``Af*sin(2*pi*t/Pf)``.  Default ``None``.
+        Optional forcing object accepted by ``PBModel`` and forwarded to the
+        base class constructor. In this implementation it is not used by
+        ``recharge_components``/``dydt``; the SST tendency retains the
+        internal seasonal term ``Af*sin(2*pi*t/Pf)``. Default ``None``.
     var_name : str
         Label for the model output.  Default ``'enso_recharge_oscillator'``.
     mu : float or callable or pb.core.Forcing

--- a/paleobeasts/signal_models/g24.py
+++ b/paleobeasts/signal_models/g24.py
@@ -4,50 +4,73 @@ from scipy.interpolate import CubicSpline
 
 
 class Model3(PBModel):
-    """
-    Model 3 from Ganopolski (2024) which describes the evolution of ice volume as a function of orbital forcing.
+    """Model 3 from Ganopolski (2024) describing glacial cycle evolution under orbital forcing.
 
-    
+    The model tracks ice volume ``v`` and glacial regime ``k`` (1 = glaciation,
+    2 = deglaciation).  The ice volume relaxes toward a forcing-dependent
+    equilibrium:
+
+        dv/dt = (ve(f) - v) / t1    when k=1  (glaciation)
+        dv/dt = -vc / t2             when k=2  (deglaciation)
+
+    Regime switches follow:
+
+    - k=1 → k=2  if v > vc, df/dt > 0, and f > 0
+    - k=2 → k=1  if f < f1
 
     Parameters
     ----------
-    Parameter defaults taken From Ganopolski 2024:
-
-    forcing : object
-        Object that provides the orbital forcing at time t and its derivative.
-
+    forcing : pb.core.Forcing
+        Orbital insolation forcing ``f(t)`` (W m\ :sup:`-2`).  Required.
     var_name : str
-        Name of the variable being modeled.
-        Default is 'ice volume'
-
-    vc : numeric, callable, or pb.Forcing
-        value for critical ice volume; controls the dominant periodicity and degree of asymmetry of glacial cycles
-        default is 1.4
-
-    f1 : numeric, callable, or pb.Forcing
-        insolation threshold for glacial inception (pinned at -20 to -15 W/m^2)
-        default is -16
-
-    t1 : numeric, callable, or pb.Forcing
-        relaxation timescale for glacial inception (in kyr)
-        default is 30
-
-    f2 : numeric, callable, or pb.Forcing
-        insolation threshold for deglaciation inception (tunable; positive)
-        default is 16
-
-    t2 : numeric, callable, or pb.Forcing
-        relaxation timescale for deglaciation (in kyr)
-        default is 10
+        Label for the model output.  Default ``'ice volume'``.
+    f1 : float or callable or pb.core.Forcing
+        Insolation threshold for glacial inception (W m\ :sup:`-2`;
+        typically -20 to -15).  Default -16.
+    f2 : float or callable or pb.core.Forcing
+        Insolation threshold for deglaciation inception (W m\ :sup:`-2`;
+        positive).  Default 16.
+    t1 : float or callable or pb.core.Forcing
+        Relaxation timescale for glacial inception (kyr).  Default 30.
+    t2 : float or callable or pb.core.Forcing
+        Relaxation timescale for deglaciation (kyr).  Default 10.
+    vc : float or callable or pb.core.Forcing
+        Critical ice volume controlling dominant periodicity and asymmetry.
+        Default 1.4.
 
     Notes
     -----
-    Time-varying parameters can be provided as callables with common signatures such as
-    ``(t)``, ``(t, state)``, ``(t, state, model)``, ``(model, state)``, or ``(state)``.
+    State variables are ``v`` (ice volume, normalised) and ``k`` (regime
+    index, non-integrated).  The diagnostic variable ``insolation`` records
+    ``f(t)`` at each output step.
 
-    params : tuple
-        Tuple of parameters (f1, f2, t1, t2, vc) for the model.
+    The internal derivative of forcing ``dfdt`` is computed via
+    :func:`calc_df` by default; supply a custom callable or
+    ``pb.core.Forcing`` to override.
 
+    Parameter defaults are taken from Ganopolski (2024).  Time-varying
+    parameters follow the standard callable contract ``(t)``,
+    ``(t, state)``, or ``(t, state, model)``.
+
+    References
+    ----------
+    Ganopolski, A. (2024). Glacial cycles. *Nature Reviews Earth &
+    Environment*, 5, 89–106.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import paleobeasts as pb
+        from paleobeasts.signal_models.g24 import Model3, calc_f
+
+        orbital_forcing = pb.core.Forcing(calc_f)
+        model = Model3(forcing=orbital_forcing)
+        output = model.integrate(
+            t_span=(-2000, 0), y0=[0.0, 1], method='RK45',
+            kwargs={'max_step': 0.5}
+        )
+        ts = output.to_pyleo(var_names=['v'])
     """
 
     def __init__(self, forcing, var_name='ice volume', f1=-16, f2=16, t1=30, t2=10, vc=1.4,
@@ -73,26 +96,13 @@ class Model3(PBModel):
         self.params = ()
 
     def dydt(self, t, x):
-        """
-        Differential equation for dv/dt (where v=ice volume) at state k.
+        """Evaluate ice-volume tendency at time ``t`` and state ``x``.
 
-        The transition from a glacial (k=1) to deglaciation regime (k = 2) occurs if:
-            - v > vc, dfdt > 0, and f > 0.
-        The transition from deglaciation (k=2) to glacial regime (k=1) occurs if:
-            - f < glaciation threshold f1.
-        The interglacial state formally belongs to the deglaciation regime.
-
-        Inputs:
-            t : time in kyr
-            x : [v] where v = ice volume
-            f1 : insolation threshold for glacial inception (pinned at -20 to -15 W/m^2)
-            f2 : insolation threshold for deglaciation inception (tunable; positive)
-            t1 : relaxation time scale for glacial inception (in kyr)
-            t2 : relaxation time scale for deglaciation (in kyr)
-
-        Returns:
-            dv/dt and dk/dt.
-
+        Returns
+        -------
+        list of float
+            ``[dvdt]`` — the ice-volume tendency.  The regime index ``k``
+            is a non-integrated state variable updated in-place.
         """
         v = x[0]  # int(self.state_variables[-1][0])
         if isinstance(v, np.ndarray):
@@ -227,78 +237,79 @@ class Model3(PBModel):
 
 
 def calc_df(t, A=25, eps=0.5, T1=100, T2=30):
-    """
-    Calculate the derivative of the orbital forcing at time t.
+    """Derivative of the Ganopolski (2024) orbital forcing at time ``t``.
 
     Parameters
     ----------
     t : float
-        Time.
-
+        Time (kyr).
     A : float
-        Magnitude of forcing in Wm−2
-        Default is 25 w/m^2
-
+        Forcing amplitude (W m\ :sup:`-2`).  Default 25.
     eps : float
-        Nondimensional magnitude of eccentricity modulation. eps = 0 corresponds to no eccentricty modulation.
-        Default is 0.5
-
+        Eccentricity modulation amplitude.  ``eps=0`` removes eccentricity
+        modulation.  Default 0.5.
     T1 : float
-        Eccentricity timescale
-        Default is 100 kyr
-
+        Eccentricity timescale (kyr).  Default 100.
     T2 : float
-        Precession timescale
-        Default is 30 kyr
+        Precession timescale (kyr).  Default 30.
 
     Returns
     -------
-    df : float
-        The value of the derivative of the orbital forcing at time t.
-
+    float
+        df/dt at time ``t``.
     """
     return A * eps * ((2 * np.pi / T1) * np.cos(2 * np.pi * t / T1) * np.cos(2 * np.pi * t / T2) -
                       (2 * np.pi / T2) * np.sin(2 * np.pi * t / T2) * np.sin(2 * np.pi * t / T1))
 
 
 def calc_f(t, A=25, eps=0.5, T1=100, T2=30):
-    """
-    Calculate the orbital forcing value at time t.
+    """Ganopolski (2024) orbital forcing value at time ``t``.
 
     Parameters
     ----------
     t : float
-        Time.
-
+        Time (kyr).
     A : float
-        Magnitude of forcing in Wm−2
-        Default is 25 w/m^2
-
+        Forcing amplitude (W m\ :sup:`-2`).  Default 25.
     eps : float
-        Nondimensional magnitude of eccentricity modulation. eps = 0 corresponds to no eccentricty modulation.
-        Default is 0.5
-
+        Eccentricity modulation amplitude.  Default 0.5.
     T1 : float
-        Eccentricity timescale
-        Default is 100 kyr
-
+        Eccentricity timescale (kyr).  Default 100.
     T2 : float
-        Precession timescale
-        Default is 30 kyr
-
+        Precession timescale (kyr).  Default 30.
 
     Returns
     -------
-    f : float
-        The value of the orbital forcing at time t.
-
+    float
+        Orbital forcing value at time ``t``.
     """
-
     return A * (1 + eps * np.sin(2 * np.pi * t / T1)) * np.cos(2 * np.pi * t / T2)
 
 
-def vc_func(t, vc1=.65, vc2=1.38, t1_mpt=-1050, tau1=250):
-    """
-    Calculate the value for critical ice volume as in Ganopolski (2024) for MPT
+def vc_func(t, vc1=0.65, vc2=1.38, t1_mpt=-1050, tau1=250):
+    """Time-varying critical ice volume for the Mid-Pleistocene Transition.
+
+    Returns a sigmoid ramp between ``vc1`` (pre-MPT) and ``vc2`` (post-MPT)
+    following Ganopolski (2024):
+
+        vc(t) = 0.5*(vc1 + vc2) + 0.5*(vc2 - vc1) * tanh((t - t1_mpt)/tau1)
+
+    Parameters
+    ----------
+    t : float
+        Time (kyr).
+    vc1 : float
+        Pre-MPT critical ice volume.  Default 0.65.
+    vc2 : float
+        Post-MPT critical ice volume.  Default 1.38.
+    t1_mpt : float
+        Centre of the MPT transition (kyr).  Default -1050.
+    tau1 : float
+        Width of the MPT transition (kyr).  Default 250.
+
+    Returns
+    -------
+    float
+        Critical ice volume at time ``t``.
     """
     return 0.5 * (vc1 + vc2) + 0.5 * (vc2 - vc1) * np.tanh((t - t1_mpt) / tau1)

--- a/paleobeasts/signal_models/lorenz.py
+++ b/paleobeasts/signal_models/lorenz.py
@@ -188,9 +188,10 @@ class Lorenz63(PBModel):
     Parameters
     ----------
     forcing : pb.core.Forcing or None
-        Optional external forcing.  If the forcing value ``f(t)`` is scalar
-        it is added to ``dx/dt``; if it is array-like with 3 entries it is
-        added to ``(dx/dt, dy/dt, dz/dt)``.
+        External forcing, which must be provided explicitly but may be
+        ``None``. If the forcing value ``f(t)`` is scalar it is added to
+        ``dx/dt``; if it is array-like with 3 entries it is added to
+        ``(dx/dt, dy/dt, dz/dt)``.
     var_name : str
         Label for the model output.  Default ``'lorenz63'``.
     sigma : float or callable or pb.core.Forcing

--- a/paleobeasts/signal_models/lorenz.py
+++ b/paleobeasts/signal_models/lorenz.py
@@ -6,45 +6,82 @@ from ..core.pbmodel import PBModel
 class Lorenz96(PBModel):
     """Lorenz (1996) single-scale and two-scale atmospheric model.
 
-    A periodic ring of *n* variables with quadratic advection and constant
-    forcing. When *J* > 0 a second, faster layer of *n* × *J* variables is
-    coupled to the slow layer (the two-scale system of Lorenz & Emanuel 1998).
+    A periodic ring of *n* slow-scale variables with quadratic advection and
+    constant forcing:
+
+        dX_k/dt = (X_{k+1} - X_{k-2}) * X_{k-1} - X_k + F
+
+    When *J* > 0 a second, faster Y layer of *n* × *J* variables is coupled
+    to the slow layer (the two-scale system of Lorenz & Emanuel 1998):
+
+        dX_k/dt = ... - (h*c/b) * sum_j Y_{j,k}
+        dY_{j,k}/dt = -c*b * Y_{j+1,k} * (Y_{j+2,k} - Y_{j-1,k}) - c*Y_{j,k} + (h*c/b)*X_k
 
     Parameters
     ----------
-    forcing : pb.Forcing or None
-        Forcing object providing F(t). If None, the constant ``F`` parameter
-        is used.
+    forcing : pb.core.Forcing or None
+        Optional forcing object providing F(t).  If ``None``, the constant
+        ``F`` parameter is used as the slow-scale forcing.
     var_name : str
-        Default ``'lorenz96'``.
+        Label for the model output.  Default ``'lorenz96'``.
     n : int
-        Number of slow-scale variables. Default 40.
+        Number of slow-scale variables.  Default 40.
     J : int
-        Fast variables per slow variable. ``J=0`` (default) gives the
-        single-scale system; ``J>0`` gives the two-scale system.
-    F : float or callable or pb.Forcing
-        Slow-scale forcing. Default 8.
+        Fast variables per slow variable.  ``J=0`` (default) gives the
+        single-scale system; ``J>0`` activates the two-scale system.
+    F : float or callable or pb.core.Forcing
+        Slow-scale forcing amplitude.  Default 8.0.
     h : float
-        Coupling coefficient between X and Y (two-scale only). Default 1.
+        Coupling coefficient between X and Y layers (two-scale only).
+        Default 1.0.
     b : float
-        Amplitude ratio Y/X (two-scale only). Default 10.
+        Amplitude ratio Y/X (two-scale only).  Default 10.0.
     c : float
-        Timescale ratio Y/X (two-scale only). Default 10.
+        Timescale ratio Y/X (two-scale only).  Default 10.0.
     exact_rhs : bool
-        If True, use global ``np.roll`` on the flattened Y vector, matching
-        the original L96_model.py. Default False (per-block loop).
+        If ``True``, use global ``np.roll`` on the flattened Y vector,
+        matching the original L96_model.py reference implementation.
+        Default ``False`` (per-block loop, identical results).
 
     Notes
     -----
-    For the two-scale system (``J>0``) use ``method='rk4'`` with
-    ``kwargs={'dt': dt, 'si': si}``. Adaptive solvers (RK45) call ``dydt``
-    at intermediate sub-steps; the fixed-step RK4 in PBModel avoids this
-    problem. Plain Euler is too coarse to resolve the Y dynamics.
+    For the two-scale system (``J>0``) use ``method='rk4'`` with a small
+    fixed time step passed directly to ``integrate``::
+
+        output = model.integrate(t_span=..., y0=..., method='rk4',
+                                 dt=0.005, kwargs={'si': 0.05})
+
+    Adaptive solvers (RK45) call ``dydt`` at unpredictable sub-steps; the
+    fixed-step RK4 avoids this problem.  Plain Euler is too coarse to
+    resolve the fast Y dynamics.
 
     References
     ----------
-    Lorenz (1996). Predictability: A problem partly solved.
-    Lorenz & Emanuel (1998). J. Atmos. Sci., 55, 399–414.
+    Lorenz, E. N. (1996). Predictability: A problem partly solved.
+    Lorenz, E. N., & Emanuel, K. A. (1998). J. Atmos. Sci., 55, 399–414.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import numpy as np
+        import paleobeasts as pb
+        from paleobeasts.signal_models.lorenz import Lorenz96
+
+        # Single-scale system
+        model = Lorenz96(forcing=None, n=40, F=8.0)
+        y0 = np.random.randn(40) + 8.0
+        output = model.integrate(t_span=(0, 10), y0=y0, method='rk4', dt=0.01)
+        ts = output.to_pyleo(var_names=['x0'])
+
+        # Two-scale system
+        K, J = 36, 10
+        model2 = Lorenz96(forcing=None, n=K, J=J, F=10.0)
+        y0_2 = np.concatenate([np.random.randn(K) + 10.0,
+                                np.random.randn(K * J) * 0.01])
+        output2 = model2.integrate(t_span=(0, 10), y0=y0_2,
+                                   method='rk4', dt=0.005,
+                                   kwargs={'si': 0.05})
     """
 
     def __init__(self, forcing=None, var_name='lorenz96', n=40, J=0,
@@ -141,28 +178,54 @@ class Lorenz96(PBModel):
 class Lorenz63(PBModel):
     """Lorenz (1963) system.
 
+    A minimal three-variable convection model exhibiting sensitive dependence
+    on initial conditions and a strange attractor:
+
+        dx/dt = sigma * (y - x)
+        dy/dt = x * (rho - z) - y
+        dz/dt = x * y - beta * z
+
     Parameters
     ----------
-    forcing : pb.Forcing
-        Forcing object providing f(t). If f(t) is a scalar, it is added to dx/dt.
-        If f(t) is array-like with 3 entries, it is added to (dx/dt, dy/dt, dz/dt).
-
+    forcing : pb.core.Forcing or None
+        Optional external forcing.  If the forcing value ``f(t)`` is scalar
+        it is added to ``dx/dt``; if it is array-like with 3 entries it is
+        added to ``(dx/dt, dy/dt, dz/dt)``.
     var_name : str
-        Name of the variable being modeled. Default is 'lorenz63'.
-
-    sigma : float or callable or pb.Forcing
-        Prandtl number. Default is 10.
-
-    rho : float or callable or pb.Forcing
-        Rayleigh number. Default is 28.
-
-    beta : float or callable or pb.Forcing
-        Geometric factor. Default is 8/3.
+        Label for the model output.  Default ``'lorenz63'``.
+    sigma : float or callable or pb.core.Forcing
+        Prandtl number controlling rotation of convective rolls.  Default 10.
+    rho : float or callable or pb.core.Forcing
+        Rayleigh number (reduced) controlling the buoyancy forcing.
+        Default 28.
+    beta : float or callable or pb.core.Forcing
+        Geometric factor controlling the spatial structure.  Default 8/3.
 
     Notes
     -----
-    Time-varying parameters can be provided as callables with common signatures such as
-    ``(t)``, ``(t, state)``, ``(t, state, model)``, ``(model, state)``, or ``(state)``.
+    The classic strange attractor exists for ``sigma=10``, ``rho=28``,
+    ``beta=8/3``.  Time-varying parameters are supported as callables with
+    signatures ``(t)``, ``(t, state)``, ``(t, state, model)``,
+    ``(model, state)``, or ``(state)``.
+
+    State variables are ``x``, ``y``, ``z`` in that order.
+
+    References
+    ----------
+    Lorenz, E. N. (1963). J. Atmos. Sci., 20, 130–141.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import paleobeasts as pb
+        from paleobeasts.signal_models.lorenz import Lorenz63
+
+        model = Lorenz63(forcing=pb.core.Forcing(lambda t: 0.0))
+        output = model.integrate(
+            t_span=(0, 100), y0=[-8.0, 8.0, 27.0], method='RK45'
+        )
+        ts = output.to_pyleo(var_names=['x', 'y', 'z'])
     """
 
     def __init__(self, forcing, var_name='lorenz63', sigma=10.0, rho=28.0, beta=8 / 3,

--- a/paleobeasts/signal_models/lorenz.py
+++ b/paleobeasts/signal_models/lorenz.py
@@ -205,8 +205,7 @@ class Lorenz63(PBModel):
     -----
     The classic strange attractor exists for ``sigma=10``, ``rho=28``,
     ``beta=8/3``.  Time-varying parameters are supported as callables with
-    signatures ``(t)``, ``(t, state)``, ``(t, state, model)``,
-    ``(model, state)``, or ``(state)``.
+    signatures ``(t)``, ``(t, state)``, or ``(t, state, model)``.
 
     State variables are ``x``, ``y``, ``z`` in that order.
 

--- a/paleobeasts/signal_models/roessler.py
+++ b/paleobeasts/signal_models/roessler.py
@@ -6,18 +6,50 @@ from paleobeasts.core.pbmodel import PBModel
 class Roessler(PBModel):
     """Roessler chaotic oscillator.
 
+    A three-variable continuous-time system with a single scroll attractor:
+
+        dx/dt = -y - z
+        dy/dt = x + a*y
+        dz/dt = b + z*(x - c)
+
     Parameters
     ----------
-    forcing : optional
-        Included for consistency with other signal models. The base dynamics do
-        not use forcing directly.
-
+    forcing : pb.core.Forcing or None
+        Included for API consistency; the base dynamics do not use forcing.
+        Default ``None``.
     var_name : str
-        Name of the variable being modeled. Default is ``'roessler'``.
+        Label for the model output.  Default ``'roessler'``.
+    a : float or callable or pb.core.Forcing
+        Controls the strength of the y-feedback.  Default 0.2.
+    b : float or callable or pb.core.Forcing
+        Offset in the z equation.  Default 0.2.
+    c : float or callable or pb.core.Forcing
+        Nonlinear threshold in the z equation.  Default 5.7.
 
-    a, b, c : float or callable or object with ``get_forcing``
-        Model parameters. Each parameter is resolved through ``get_param`` so
-        time-varying callables and ``Forcing`` objects are supported.
+    Notes
+    -----
+    The canonical chaotic attractor exists near ``a=b=0.2``, ``c=5.7``.
+    State variables are ``x``, ``y``, ``z`` in that order.
+    Time-varying parameters are resolved through ``get_param_value`` and
+    support callables with signatures ``(t)``, ``(t, state)``, or
+    ``(t, state, model)``.
+
+    References
+    ----------
+    Rössler, O. E. (1976). Phys. Lett. A, 57(5), 397–398.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import paleobeasts as pb
+        from paleobeasts.signal_models.roessler import Roessler
+
+        model = Roessler(forcing=None)
+        output = model.integrate(
+            t_span=(0, 200), y0=[0.1, 0.0, 0.0], method='RK45'
+        )
+        ts = output.to_pyleo(var_names=['x', 'y', 'z'])
     """
 
     def __init__(

--- a/paleobeasts/signal_models/roessler.py
+++ b/paleobeasts/signal_models/roessler.py
@@ -54,7 +54,7 @@ class Roessler(PBModel):
 
     def __init__(
         self,
-        forcing,
+        forcing=None,
         var_name='roessler',
         a=0.2,
         b=0.2,

--- a/paleobeasts/signal_models/stocker2003_bipolar_seesaw.py
+++ b/paleobeasts/signal_models/stocker2003_bipolar_seesaw.py
@@ -15,7 +15,59 @@ from ..core.pbmodel import PBModel
 
 
 class Stocker2003BipolarSeesaw(PBModel):
-    """Minimum thermodynamic model for the thermal bipolar seesaw."""
+    """Minimum thermodynamic model for the thermal bipolar seesaw.
+
+    A single prognostic southern temperature anomaly ``Ts`` relaxes toward
+    a northern temperature signal ``Tn(t)`` scaled by ``beta``:
+
+        dTs/dt = (beta*Tn(t) - Ts) / tau
+
+    Parameters
+    ----------
+    forcing : pb.core.Forcing or None
+        Optional time-varying northern temperature anomaly ``Tn(t)``
+        (model units).  If ``None``, the constant ``Tn`` parameter is used.
+        Default ``None``.
+    var_name : str
+        Label for the model output.  Default ``'stocker2003_bipolar_seesaw'``.
+    tau : float or callable or pb.core.Forcing
+        Thermal equilibration timescale (years).  Must be > 0.  Default 1000.
+    beta : float or callable or pb.core.Forcing
+        Amplitude ratio relating southern to northern anomaly.  Default -1.0
+        (antiphase seesaw).
+    Tn : float or callable or pb.core.Forcing
+        Constant northern temperature anomaly used when no forcing is
+        provided.  Default 0.0.
+
+    Notes
+    -----
+    The diagnostic variable ``Tn`` (northern temperature) is written by
+    ``populate_diagnostics_from_history`` after integration.  State variable
+    is ``Ts``.
+
+    References
+    ----------
+    Stocker, T. F., & Johnsen, S. J. (2003). A minimum thermodynamic model
+    for the bipolar seesaw. Paleoceanography, 18(4), 1087.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import numpy as np
+        import paleobeasts as pb
+        from paleobeasts.signal_models.stocker2003_bipolar_seesaw import (
+            Stocker2003BipolarSeesaw,
+        )
+
+        # Square-wave northern forcing
+        Tn = pb.core.Forcing(lambda t: 1.0 if (t % 2000) < 1000 else -1.0)
+        model = Stocker2003BipolarSeesaw(forcing=Tn, tau=500.0, beta=-1.0)
+        output = model.integrate(
+            t_span=(0, 8000), y0=[0.0], method='RK45'
+        )
+        ts = output.to_pyleo(var_names=['Ts'])
+    """
 
     def __init__(
         self,
@@ -84,15 +136,81 @@ class Stocker2003BipolarSeesaw(PBModel):
 class Stocker2003ExtendedSeaIceSeesaw(PBModel):
     """Extended Stocker-style model with reservoir, Southern Ocean, sea-ice, and Antarctic states.
 
-    The model integrates four coupled ODEs with prescribed northern forcing T_N(t):
+    The model integrates four coupled ODEs with prescribed northern forcing
+    ``T_N(t)``:
 
-        tau_R * dT_R/dt   = -(T_R - T_N) + epsilon_R
-        tau_S * dT_S/dt   = kappa*(T_R - T_S) - lambda_S*(T_S - T_S0) + alpha*(1 - A) + epsilon_S
-        tau_A * dA/dt     = -beta*(T_S - T_S0) - gamma*A*(1-A)*(T_S - T_c) + epsilon_A
-        tau_ANT * dT_ANT/dt = delta*(T_S - T_ANT) + eta*(1-A) + epsilon_ANT
+        tau_R * dT_R/dt     = -(T_R - T_N) + eps_R
+        tau_S * dT_S/dt     = kappa*(T_R - T_S) - lambda_S*(T_S - T_S0)
+                              + alpha*(1 - A) + eps_S
+        tau_A * dA/dt       = -beta*(T_S - T_S0)
+                              - gamma*A*(1-A)*(T_S - T_c) + eps_A
+        tau_ANT * dT_ANT/dt = delta*(T_S - T_ANT) + eta*(1 - A) + eps_ANT
 
-    Sea-ice area fraction ``A`` is physically constrained to [0, 1] by
-    suppressing the outward derivative at the boundaries inside ``dydt``.
+    Sea-ice area fraction ``A`` is constrained to [0, 1] by suppressing
+    the outward derivative at the physical boundaries inside ``dydt``.
+
+    Parameters
+    ----------
+    forcing : pb.core.Forcing or None
+        Optional time-varying northern temperature anomaly ``T_N(t)``.  If
+        ``None``, the constant ``T_N`` parameter is used.  Default ``None``.
+    var_name : str
+        Label for the model output.  Default
+        ``'stocker2003_extended_seaice_seesaw'``.
+    tau_R : float
+        Oceanic reservoir relaxation timescale (years).  Default 300.
+    tau_S : float
+        Southern Ocean relaxation timescale (years).  Default 1200.
+    tau_A : float
+        Sea-ice adjustment timescale (years).  Default 100.
+    tau_ANT : float
+        Antarctic temperature adjustment timescale (years).  Default 20.
+    kappa : float
+        Advective heat exchange between reservoir and Southern Ocean.
+        Default 1.0.
+    lambda_S : float
+        Linear restoring rate for Southern Ocean temperature.  Default 0.2.
+    alpha : float
+        Sea-ice insulation effect on Southern Ocean heat flux.  Default 0.3.
+    beta : float
+        Temperature-driven sea-ice melt rate.  Default 0.2.
+    gamma : float
+        Nonlinear sea-ice feedback strength.  Default 4.0.
+    delta : float
+        Southern Ocean to Antarctic heat coupling.  Default 1.0.
+    eta : float
+        Sea-ice insulation effect on Antarctic temperature.  Default 0.2.
+    T_S0 : float
+        Reference Southern Ocean temperature.  Default 0.0.
+    T_c : float
+        Critical temperature for the sea-ice feedback.  Default 0.0.
+    T_N : float
+        Constant northern temperature when no forcing is provided.
+        Default 0.0.
+    epsilon_R, epsilon_S, epsilon_A, epsilon_ANT : float
+        Constant additive noise / bias terms.  All default to 0.0.
+
+    Notes
+    -----
+    State variables are ``T_R``, ``T_S``, ``A``, ``T_ANT`` in that order.
+    The diagnostic variable ``T_N`` is populated by
+    ``populate_diagnostics_from_history``.  All timescales must be > 0.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import paleobeasts as pb
+        from paleobeasts.signal_models.stocker2003_bipolar_seesaw import (
+            Stocker2003ExtendedSeaIceSeesaw,
+        )
+
+        T_N = pb.core.Forcing(lambda t: 1.0 if (t % 2000) < 1000 else 0.0)
+        model = Stocker2003ExtendedSeaIceSeesaw(forcing=T_N)
+        output = model.integrate(
+            t_span=(0, 10000), y0=[0.0, 0.0, 0.3, 0.0], method='RK45'
+        )
+        ts = output.to_pyleo(var_names=['T_ANT'])
     """
 
     def __init__(

--- a/paleobeasts/signal_models/stommel.py
+++ b/paleobeasts/signal_models/stommel.py
@@ -8,28 +8,65 @@ from ..core.pbmodel import PBModel
 class Stommel(PBModel):
     """Minimal two-box Stommel thermohaline circulation model.
 
-    State variables are temperature contrast ``T`` and salinity contrast ``S``.
-    The overturning strength is parameterized as:
+    State variables are the pole-to-equator temperature contrast ``T`` and
+    salinity contrast ``S``.  The overturning strength is parameterized as:
 
-    ``q = k * (alpha * T - beta * S)``
+        q = k * (alpha*T - beta*S)
 
-    and the prognostic system is:
+    and the prognostic equations are:
 
-    ``dT/dt = -lambda_T * (T - T_star) - |q| * T + f_T(t)``
-    ``dS/dt = E - lambda_S * (S - S_star) - |q| * S + f_S(t)``
+        dT/dt = -lambda_T * (T - T_star) - |q|*T + f_T(t)
+        dS/dt =  E - lambda_S * (S - S_star) - |q|*S + f_S(t)
 
     Parameters
     ----------
-    forcing : pb.Forcing or None
-        Optional external forcing. If scalar, it is added to salinity tendency
-        (freshwater forcing term). If array-like with 2 entries, it is added to
-        ``(dT/dt, dS/dt)``.
-
+    forcing : pb.core.Forcing or None
+        Optional external forcing.  If the forcing value is scalar it is
+        applied as a freshwater perturbation added to ``dS/dt``.  If
+        array-like with 2 entries, it is added to ``(dT/dt, dS/dt)``
+        respectively.  Default ``None``.
     var_name : str
-        Name of the modeled quantity. Default is ``'stommel'``.
+        Label for the model output.  Default ``'stommel'``.
+    alpha : float or callable or pb.core.Forcing
+        Thermal expansion coefficient.  Default 1.0.
+    beta : float or callable or pb.core.Forcing
+        Haline contraction coefficient.  Default 1.0.
+    k : float or callable or pb.core.Forcing
+        Hydraulic constant controlling overturning sensitivity.  Default 1.0.
+    E : float or callable or pb.core.Forcing
+        Net evaporation-minus-precipitation freshwater flux.  Default 0.0.
+    lambda_T : float or callable or pb.core.Forcing
+        Thermal restoring rate.  Default 1.0.
+    lambda_S : float or callable or pb.core.Forcing
+        Saline restoring rate.  Default 1.0.
+    T_star : float or callable or pb.core.Forcing
+        Equilibrium temperature contrast.  Default 1.0.
+    S_star : float or callable or pb.core.Forcing
+        Equilibrium salinity contrast.  Default 0.0.
 
-    alpha, beta, k, E, lambda_T, lambda_S, T_star, S_star : float or callable or pb.Forcing
-        Model parameters. Can be constants, callables, or Forcing objects.
+    Notes
+    -----
+    The model uses ``uses_post_history`` to compute the overturning
+    diagnostic ``q`` after integration.  State variables are ``T`` and ``S``;
+    diagnostic variable is ``q``.
+
+    References
+    ----------
+    Stommel, H. (1961). Thermohaline convection with two stable regimes of
+    flow. Tellus, 13(2), 224–230.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import paleobeasts as pb
+        from paleobeasts.signal_models.stommel import Stommel
+
+        model = Stommel(forcing=None, E=0.3, T_star=1.0, S_star=0.0)
+        output = model.integrate(
+            t_span=(0, 50), y0=[1.0, 0.0], method='RK45'
+        )
+        ts_q = output.to_pyleo(var_names=['q'])
     """
 
     def __init__(self, forcing=None, var_name='stommel', alpha=1.0, beta=1.0, k=1.0, E=0.0,

--- a/paleobeasts/signal_models/two_box_carbon.py
+++ b/paleobeasts/signal_models/two_box_carbon.py
@@ -8,9 +8,55 @@ from paleobeasts.core.pbmodel import PBModel
 class TwoBoxCarbon(PBModel):
     """Two-box carbon exchange model with explicit box volumes.
 
-    State variables ``A`` and ``S`` are carbon inventories in the atmospheric
-    and surface-ocean boxes. Air-sea exchange is driven by the difference in
-    box concentrations, computed from the explicit box volumes.
+    State variables ``A`` and ``S`` are carbon inventories (mass units) in the
+    atmospheric and surface-ocean boxes respectively.  Air-sea exchange is
+    driven by the concentration gradient:
+
+        exchange = k * (A/V_atm - S/V_surf)
+        dA/dt = -exchange + R - l_s*A
+        dS/dt = exchange
+
+    Parameters
+    ----------
+    forcing : pb.core.Forcing or None
+        Optional prescribed carbon source flux ``R(t)`` (same units as
+        ``R``).  If provided it overrides the constant ``R`` parameter.
+        Default ``None``.
+    var_name : str
+        Label for the model output.  Default ``'two_box_carbon'``.
+    k : float or callable or pb.core.Forcing
+        Air-sea gas exchange rate constant (volume units per time).
+        Default 0.2.
+    R : float or callable or pb.core.Forcing
+        Constant carbon source flux into the atmosphere (mass per time).
+        Default 0.0.
+    l_s : float or callable or pb.core.Forcing
+        First-order atmospheric loss coefficient.  Default 0.0.
+    V_atm : float or callable or pb.core.Forcing
+        Volume of the atmospheric box (must be > 0).  Default 1.0.
+    V_surf : float or callable or pb.core.Forcing
+        Volume of the surface-ocean box (must be > 0).  Default 1.0.
+
+    Notes
+    -----
+    Diagnostic variable ``net_flux`` (the atmospheric tendency ``dA/dt``)
+    is computed in ``populate_diagnostics_from_history`` after integration.
+
+    ``V_atm`` and ``V_surf`` must be positive; ``ValueError`` is raised if
+    either is ≤ 0.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import paleobeasts as pb
+        from paleobeasts.signal_models.two_box_carbon import TwoBoxCarbon
+
+        model = TwoBoxCarbon(forcing=None, k=0.1, V_atm=1.0, V_surf=50.0)
+        output = model.integrate(
+            t_span=(0, 200), y0=[800.0, 38000.0], method='RK45'
+        )
+        ts = output.to_pyleo(var_names=['A', 'S'])
     """
 
     def __init__(


### PR DESCRIPTION
Expand and clarify documentation across multiple signal model modules. Updated docstrings to include parameter descriptions, notes, state/diagnostic variable ordering, examples, references, and behavioral clarifications (forcing handling, bounds, diagnostics). Specific files updated: paleobeasts/signal_models/box_model.py (BoxModelSpec/GenericBoxModel docs), daisyworld.py, enso_recharge.py, g24.py (Model3, calc_f/df, vc_func), lorenz.py (Lorenz96/Lorenz63), roessler.py, stocker2003_bipolar_seesaw.py (both models), stommel.py, and two_box_carbon.py. These changes improve API usability by documenting defaults, units/semantics, constraints (e.g. Pf != 0, positive volumes/timescales), and example usage; no functional logic changes were made.