### PR TITLE
Introduce resolve_forcing and refactor models

### DIFF
--- a/paleobeasts/core/pbmodel.py
+++ b/paleobeasts/core/pbmodel.py
@@ -142,6 +142,19 @@ class PBModel:
 
 
 
+    def resolve_forcing(self, t, default=0.0):
+        """Evaluate the model's external forcing at time t.
+
+        If no forcing object is attached (``self.forcing is None``), returns
+        ``default``, which the caller supplies — a fallback parameter value, a
+        zero vector, or a computed internal term.  Keeping the fallback out of
+        this method preserves the distinction between forcings (external drivers)
+        and parameters (intrinsic model properties).
+        """
+        if self.forcing is None:
+            return default
+        return self.forcing.get_forcing(self.time_util(t))
+
     def get_param_value(self, name, t, state):
         """Resolve a named parameter to its value at the current time and state.
 

--- a/paleobeasts/signal_models/damped_spring.py
+++ b/paleobeasts/signal_models/damped_spring.py
@@ -114,9 +114,7 @@ class DampedSpring(PBModel):
         if k <= 0.0:
             raise ValueError("k must be > 0.")
 
-        F = 0.0
-        if self.forcing is not None:
-            F = float(self.forcing.get_forcing(self.time_util(t)))
+        F = float(self.resolve_forcing(t))
 
         dxdt = vel
         dvdt = -(c / m) * vel - (k / m) * pos + F / m

--- a/paleobeasts/signal_models/enso_recharge.py
+++ b/paleobeasts/signal_models/enso_recharge.py
@@ -19,10 +19,9 @@ class ENSORechargeOscillator(PBModel):
     Parameters
     ----------
     forcing : pb.core.Forcing or None
-        Optional forcing object accepted by ``PBModel`` and forwarded to the
-        base class constructor. In this implementation it is not used by
-        ``recharge_components``/``dydt``; the SST tendency retains the
-        internal seasonal term ``Af*sin(2*pi*t/Pf)``. Default ``None``.
+        External forcing used in ``dT/dt``. If provided it replaces the
+        internal seasonal term ``Af*sin(2*pi*t/Pf)`` entirely. Default
+        ``None``.
     var_name : str
         Label for the model output.  Default ``'enso_recharge_oscillator'``.
     mu : float or callable or pb.core.Forcing
@@ -30,9 +29,11 @@ class ENSORechargeOscillator(PBModel):
     en : float or callable or pb.core.Forcing
         Nonlinear damping coefficient.  Default 0.0 (linear limit).
     Af : float or callable or pb.core.Forcing
-        Seasonal forcing amplitude.  Default 0.0.
+        Seasonal forcing amplitude used only when ``forcing`` is ``None``.
+        Default 0.0.
     Pf : float or callable or pb.core.Forcing
-        Seasonal forcing period (model time units).  Default 6.0.
+        Seasonal forcing period (model time units), used only when
+        ``forcing`` is ``None``. Default 6.0.
     c : float or callable or pb.core.Forcing
         Newtonian cooling rate of SST.  Default 1.0.
     r : float or callable or pb.core.Forcing
@@ -50,8 +51,9 @@ class ENSORechargeOscillator(PBModel):
     this is baked in but does not affect ``t`` directly as the equations are
     already in the dimensionless form used in the worksheet.
 
-    State variables are ``T`` and ``h`` in that order.  ``Pf`` must be
-    non-zero (raises ``ValueError`` otherwise).
+    State variables are ``T`` and ``h`` in that order. ``Pf`` must be
+    non-zero when the internal seasonal forcing is used (raises
+    ``ValueError`` otherwise).
 
     References
     ----------
@@ -130,6 +132,14 @@ class ENSORechargeOscillator(PBModel):
     def uses_post_history(self):
         return True
 
+    def _sst_forcing(self, t, state):
+        Af = float(self.get_param_value("Af", t, state))
+        Pf = float(self.get_param_value("Pf", t, state))
+        if Pf == 0.0:
+            raise ValueError("Pf must be non-zero.")
+        seasonal = Af * np.sin(2.0 * np.pi * t / Pf)
+        return float(self.resolve_forcing(t, default=seasonal))
+
     def recharge_components(self, t, state):
         T, h = [float(v) for v in np.asarray(state, dtype=float).reshape(-1)]
         mu = float(self.get_param_value("mu", t, state))
@@ -139,17 +149,12 @@ class ENSORechargeOscillator(PBModel):
         alpha = float(self.get_param_value("alpha", t, state))
         b0 = float(self.get_param_value("b0", t, state))
         gamma = float(self.get_param_value("gamma", t, state))
-        Af = float(self.get_param_value("Af", t, state))
-        Pf = float(self.get_param_value("Pf", t, state))
-
-        if Pf == 0.0:
-            raise ValueError("Pf must be non-zero.")
 
         b = b0 * mu
         R = gamma * b - c
-        seasonal_forcing = Af * np.sin(2.0 * np.pi * t / Pf)
+        forcing_term = self._sst_forcing(t, state)
 
-        dT = R * T + gamma * h - en * (h + b * T) ** 3 + seasonal_forcing
+        dT = R * T + gamma * h - en * (h + b * T) ** 3 + forcing_term
         dh = -r * h - alpha * b * T
         return dT, dh
 

--- a/paleobeasts/signal_models/lorenz.py
+++ b/paleobeasts/signal_models/lorenz.py
@@ -110,9 +110,7 @@ class Lorenz96(PBModel):
         self.params = ()
 
     def _forcing_value(self, t, x):
-        if self.forcing is None:
-            return self.get_param_value('F', t, x)
-        return self.forcing.get_forcing(self.time_util(t))
+        return self.resolve_forcing(t, default=self.get_param_value('F', t, x))
 
     def dydt(self, t, x):
         x = np.asarray(x, dtype=float)
@@ -228,7 +226,7 @@ class Lorenz63(PBModel):
         ts = output.to_pyleo(var_names=['x', 'y', 'z'])
     """
 
-    def __init__(self, forcing, var_name='lorenz63', sigma=10.0, rho=28.0, beta=8 / 3,
+    def __init__(self, forcing=None, var_name='lorenz63', sigma=10.0, rho=28.0, beta=8 / 3,
                  state_variables=None, diagnostic_variables=None, *args, **kwargs):
         if state_variables is None:
             state_variables = ['x', 'y', 'z']
@@ -249,10 +247,7 @@ class Lorenz63(PBModel):
         self.params = ()
 
     def _forcing_vector(self, t):
-        if self.forcing is None:
-            return np.zeros(3)
-
-        f_val = self.forcing.get_forcing(self.time_util(t))
+        f_val = self.resolve_forcing(t)
 
         if np.isscalar(f_val):
             return np.array([f_val, 0.0, 0.0])

--- a/paleobeasts/signal_models/pendulum.py
+++ b/paleobeasts/signal_models/pendulum.py
@@ -47,7 +47,9 @@ class SimplePendulum(PBModel):
     Parameters
     ----------
     forcing:
-        Not used by default; reserved for subclassing.
+        Optional external torque applied additively to ``dω/dt``.  A scalar
+        ``Forcing`` value is added directly; if ``None``, the unforced
+        dynamics are used.
     var_name:
         Human-readable label.
     L:
@@ -111,7 +113,7 @@ class SimplePendulum(PBModel):
 
         omega0_sq = g / L
         dtheta = omega
-        domega = -lam * omega - omega0_sq * np.sin(theta)
+        domega = -lam * omega - omega0_sq * np.sin(theta) + self.resolve_forcing(t)
         return [dtheta, domega]
 
     def populate_diagnostics_from_history(self, time, history):
@@ -168,8 +170,9 @@ class DrivenPendulum(PBModel):
     Parameters
     ----------
     forcing:
-        Optional.  If provided, ``forcing.get_forcing(t)`` replaces the
-        cosine drive term entirely (allows arbitrary drive waveforms).
+        Optional external drive.  If provided, ``forcing.get_forcing(t)``
+        replaces the built-in cosine term entirely, allowing arbitrary drive
+        waveforms.  When ``None``, the cosine drive ``A cos(Ω t)`` is used.
     var_name:
         Human-readable label.
     q:
@@ -221,11 +224,9 @@ class DrivenPendulum(PBModel):
         return True
 
     def _drive(self, t):
-        if self.forcing is not None:
-            return float(self.forcing.get_forcing(self.time_util(t)))
         A = float(self.param_values["A"])
         Omega = float(self.param_values["Omega"])
-        return A * np.cos(Omega * t)
+        return float(self.resolve_forcing(t, default=A * np.cos(Omega * t)))
 
     def dydt(self, t, x):
         state = np.asarray(x, dtype=float).reshape(-1)
@@ -276,7 +277,9 @@ class DoublePendulum(PBModel):
     Parameters
     ----------
     forcing:
-        Not used; included for interface consistency.
+        Optional external torque applied additively to ``dω₁/dt`` (the first
+        bob).  A scalar ``Forcing`` value is added directly; if ``None``, the
+        unforced dynamics are used.
     var_name:
         Human-readable label.
     m1, m2:
@@ -370,7 +373,7 @@ class DoublePendulum(PBModel):
             -g * (2.0 * m1 + m2) * np.sin(theta1)
             - m2 * g * np.sin(theta1 - 2.0 * theta2)
             - 2.0 * sin_d * m2 * (omega2 ** 2 * L2 + omega1 ** 2 * L1 * cos_d)
-        ) / denom - d1 * omega1
+        ) / denom - d1 * omega1 + self.resolve_forcing(t)
 
         domega2 = (
             2.0 * sin_d * (

--- a/paleobeasts/signal_models/roessler.py
+++ b/paleobeasts/signal_models/roessler.py
@@ -15,8 +15,9 @@ class Roessler(PBModel):
     Parameters
     ----------
     forcing : pb.core.Forcing or None
-        Included for API consistency; the base dynamics do not use forcing.
-        Default ``None``.
+        External forcing applied additively to the equations.  If the value
+        at time t is scalar it is added to dx/dt only; if it is a 3-element
+        array it is added component-wise.  Default ``None``.
     var_name : str
         Label for the model output.  Default ``'roessler'``.
     a : float or callable or pb.core.Forcing
@@ -88,15 +89,25 @@ class Roessler(PBModel):
         }
         self.params = ()
 
+    def _forcing_vector(self, t):
+        f_val = self.resolve_forcing(t)
+        if np.isscalar(f_val):
+            return np.array([f_val, 0.0, 0.0])
+        f_arr = np.asarray(f_val, dtype=float)
+        if f_arr.size != 3:
+            raise ValueError("Forcing must be a scalar or an array-like with 3 entries.")
+        return f_arr.reshape(3,)
+
     def dydt(self, t, state):
         x_val, y_val, z_val = state[0], state[1], state[2]
         a = self.get_param_value('a', t, state)
         b = self.get_param_value('b', t, state)
         c = self.get_param_value('c', t, state)
 
-        dxdt = -y_val - z_val
-        dydt = x_val + a * y_val
-        dzdt = b + z_val * (x_val - c)
+        f_vec = self._forcing_vector(t)
+        dxdt = -y_val - z_val + f_vec[0]
+        dydt = x_val + a * y_val + f_vec[1]
+        dzdt = b + z_val * (x_val - c) + f_vec[2]
 
         new_row = np.array([(x_val, y_val, z_val)], dtype=self.dtypes)
         self.state_variables = np.concatenate([self.state_variables, new_row], axis=0)

--- a/paleobeasts/signal_models/stocker2003_bipolar_seesaw.py
+++ b/paleobeasts/signal_models/stocker2003_bipolar_seesaw.py
@@ -113,10 +113,7 @@ class Stocker2003BipolarSeesaw(PBModel):
         if tau <= 0:
             raise ValueError("tau must be > 0.")
         beta = float(self.get_param_value("beta", t, x))
-        if self.forcing is not None:
-            Tn_t = float(self.forcing.get_forcing(self.time_util(t)))
-        else:
-            Tn_t = float(self.get_param_value("Tn", t, x))
+        Tn_t = float(self.resolve_forcing(t, default=self.get_param_value("Tn", t, x)))
         dTsdt = (beta * Tn_t - Ts) / tau
         return [dTsdt]
 
@@ -125,10 +122,7 @@ class Stocker2003BipolarSeesaw(PBModel):
         history = np.asarray(history, dtype=float)
         Tn_vals = []
         for t, row in zip(time, history):
-            if self.forcing is not None:
-                Tn_vals.append(float(self.forcing.get_forcing(self.time_util(t))))
-            else:
-                Tn_vals.append(float(self.get_param_value("Tn", t, row)))
+            Tn_vals.append(float(self.resolve_forcing(t, default=self.get_param_value("Tn", t, row))))
         Tn_vals = np.asarray(Tn_vals, dtype=float)
         self.diagnostic_variables = {"Tn": Tn_vals}
 
@@ -298,9 +292,7 @@ class Stocker2003ExtendedSeaIceSeesaw(PBModel):
     uses_post_history = True
 
     def resolve_north(self, t, state):
-        if self.forcing is not None:
-            return float(self.forcing.get_forcing(self.time_util(t)))
-        return float(self.get_param_value("T_N", t, state))
+        return float(self.resolve_forcing(t, default=self.get_param_value("T_N", t, state)))
 
     def dydt(self, t, x):
         state = np.asarray(x, dtype=float).reshape(-1)

--- a/paleobeasts/signal_models/stommel.py
+++ b/paleobeasts/signal_models/stommel.py
@@ -101,10 +101,7 @@ class Stommel(PBModel):
         self.params = ()
 
     def _forcing_vector(self, t):
-        if self.forcing is None:
-            return np.zeros(2)
-
-        f_val = self.forcing.get_forcing(self.time_util(t))
+        f_val = self.resolve_forcing(t)
         if np.isscalar(f_val):
             return np.array([0.0, float(f_val)])
 

--- a/paleobeasts/tests/test_signal_models_enso_recharge.py
+++ b/paleobeasts/tests/test_signal_models_enso_recharge.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy import integrate
 
+from paleobeasts.core.forcing import Forcing
 from paleobeasts.signal_models import ENSORechargeOscillator
 
 
@@ -61,6 +62,29 @@ class TestSignalModelsENSORechargeOscillator:
 
         got = np.column_stack([model.state_variables["T"], model.state_variables["h"]])
         assert np.allclose(got, x_ref, rtol=1e-6, atol=1e-6)
+
+    def test_external_forcing_replaces_internal_seasonal_term(self):
+        forcing = Forcing(lambda t: 2.5)
+        model = ENSORechargeOscillator(forcing=forcing, mu=0.8, en=0.2, Af=999.0, Pf=6.0)
+
+        dT, dh = model.recharge_components(1.5, [0.1, -0.2])
+
+        mu = 0.8
+        en = 0.2
+        c = 1.0
+        r = 0.25
+        alpha = 0.125
+        b0 = 2.5
+        gamma = 0.75
+        T = 0.1
+        h = -0.2
+        b = b0 * mu
+        R = gamma * b - c
+        expected_dT = R * T + gamma * h - en * (h + b * T) ** 3 + 2.5
+        expected_dh = -r * h - alpha * b * T
+
+        assert np.isclose(dT, expected_dT)
+        assert np.isclose(dh, expected_dh)
 
     def test_enso_like_period_t0(self):
         model = ENSORechargeOscillator(mu=0.8, en=3.0, Af=0.0, Pf=6.0)


### PR DESCRIPTION
Add PBModel.resolve_forcing(t, default) to centralize resolving external forcings with a caller-supplied fallback. Refactor multiple signal models (damped_spring, enso_recharge, lorenz, pendulum, roessler, stocker2003_bipolar_seesaw, stommel) to use resolve_forcing and simplify forcing handling and docs. ENSORechargeOscillator now supports replacing the internal seasonal term with an external Forcing (new _sst_forcing helper) and a unit test was added to verify this behavior; tests import Forcing accordingly.