### PR TITLE
Use protected _validate_initial_state hook

### DIFF
--- a/paleobeasts/core/pbmodel.py
+++ b/paleobeasts/core/pbmodel.py
@@ -316,7 +316,7 @@ class PBModel:
         self.diagnostic_variables = {var: [] for var in self.diagnostic_variables}
 
         # --- validate and normalise initial state ---
-        y0 = self.validate_initial_state(y0)
+        y0 = self._validate_initial_state(y0)
         self.y0 = y0
         self.t_span = t_span
 
@@ -407,13 +407,14 @@ class PBModel:
         """
         return None
 
-    def validate_initial_state(self, y0):
+    def _validate_initial_state(self, y0):
         """Validate and normalize the initial state vector.
 
-        Exists as a method so that subclasses with non-standard initial state
-        requirements (e.g. a spatially discretised model that accepts a scalar
-        and broadcasts it to the grid) can override it.  The base implementation
-        delegates to the utility in ``utils/solver``.
+        Protected hook called by ``integrate()`` before the solver runs.
+        Subclasses with non-standard initial state requirements (e.g. a
+        spatially discretised model that accepts a scalar and broadcasts it
+        to the grid) override this method.  The base implementation delegates
+        to the utility in ``utils/solver``.
         """
         return _validate_initial_state(y0, self.integrated_state_vars, self.state_variables_names)
 

--- a/paleobeasts/signal_models/ebm.py
+++ b/paleobeasts/signal_models/ebm.py
@@ -364,13 +364,18 @@ class EBM1DLat(EBMBase):
     from the full solved trajectory in ``populate_diagnostics_from_history``
     rather than accumulated step-by-step in ``dydt``.
 
-    ``validate_initial_state`` accepts a scalar and broadcasts it uniformly
-    to the full grid.
+    Accepts a scalar ``y0`` and broadcasts it uniformly to the full grid
+    (via the ``_validate_initial_state`` hook).
 
     All parameters (``C``, ``D``, ``A``, ``B``, ``S0``, ``CO2_forcing``) are
     registered in ``param_values`` and can be swapped for callables or
     Forcing objects at any time.  Callables must follow the contract in
     ``contracts/signal_model_contract.md``.
+
+    **Numerical stability**: the explicit RK4 scheme is subject to a CFL-like
+    stability condition from the diffusion term.  With the default parameters
+    (``D=0.55``, ``grid_n=50``) use ``dt ≤ 0.1``; larger timesteps will
+    overflow.
 
     See also
     --------
@@ -389,7 +394,7 @@ class EBM1DLat(EBMBase):
     grid_n = 50
     model = EBM1DLat(forcing=None, S0=1365.0, grid_n=grid_n)
     output = model.integrate(
-        t_span=(0, 200), y0=np.full(grid_n, 15.0), method='rk4', dt=1.0
+        t_span=(0, 200), y0=np.full(grid_n, 15.0), method='rk4', dt=0.1
     )
     # Plot the equilibrium latitude–temperature profile
     T_final = [output.state_variables[f'T_{i}'][-1] for i in range(grid_n)]
@@ -448,10 +453,10 @@ class EBM1DLat(EBMBase):
         }
         self.params = ()
 
-    def validate_initial_state(self, y0):
+    def _validate_initial_state(self, y0):
         """Validate and normalize the initial temperature profile.
 
-        Overrides :meth:`PBModel.validate_initial_state` to accept a scalar
+        Overrides :meth:`PBModel._validate_initial_state` to accept a scalar
         initial condition and broadcast it uniformly across the latitude grid.
 
         Parameters
@@ -636,6 +641,10 @@ class EBM1DLat(EBMBase):
             phi_side = phi_side[order]
             temp_side = temp_side[order]
 
+            # Guard: NaN values (diverged integration) propagate as NaN.
+            if np.any(np.isnan(temp_side)):
+                hemi_edges.append(np.nan)
+                continue
             if np.all(temp_side > threshold):
                 hemi_edges.append(90.0)
                 continue


### PR DESCRIPTION
Rename PBModel.validate_initial_state to a protected hook _validate_initial_state and update its caller in integrate(). Update docstrings to describe the protected hook and that subclasses should override it; base implementation still delegates to the utils/solver helper.

In EBM1DLat, switch the override to _validate_initial_state, update docs to reference the new hook, add a numerical-stability note (explicit RK4 diffusion CFL-like limit; with default params use dt ≤ 0.1) and change the example integration dt to 0.1. Also add a guard in the hemisphere-edge detection to propagate NaN (append NaN and continue) when the temperature slice contains NaNs from a diverged integration.