### PR TITLE
Register forcing

### DIFF
--- a/paleobeasts/core/forcing.py
+++ b/paleobeasts/core/forcing.py
@@ -525,6 +525,72 @@ class Forcing:
         return self.forcing_func(t)
 
 
+_VALID_ATTACHMENT_STYLES = {"replacement", "additive"}
+_VALID_TIMINGS = {"pre", "post"}
+
+
+@dataclass
+class ForcingSpec:
+    """Registration record for a single forcing attachment on a model variable.
+
+    Created internally by ``PBModel.set_forcing``; users do not construct this
+    directly.  All fields are validated at construction time.
+
+    Parameters
+    ----------
+    forcing_object :
+        A ``Forcing`` instance, a callable ``f(t)`` → scalar/array, or any
+        object with a ``get_forcing(t)`` method.
+    attachment_style : {"replacement", "additive"}
+        How the forcing value is applied to the target variable.
+        ``"replacement"`` substitutes the current parameter or state value.
+        ``"additive"`` adds the forcing value to the existing value or to
+        ``dx/dt`` for state variables.
+    timing : {"pre", "post"}
+        When the forcing is applied relative to the integration step.
+        ``"pre"`` — applied inside the RHS before the integrator advances.
+        ``"post"`` — applied as a correction after the integrator step.
+
+    Notes
+    -----
+    Derivation rules (enforced by ``set_forcing``, not here):
+
+    * parameter + replacement  →  timing always ``"pre"``
+    * state + replacement      →  timing always ``"post"``
+    * state + additive         →  timing required from caller
+    """
+
+    forcing_object: object
+    attachment_style: str
+    timing: str
+
+    def __post_init__(self):
+        if self.attachment_style not in _VALID_ATTACHMENT_STYLES:
+            valid = ", ".join(sorted(_VALID_ATTACHMENT_STYLES))
+            raise ValueError(
+                f"attachment_style must be one of {{{valid}}}; "
+                f"got {self.attachment_style!r}."
+            )
+        if self.timing not in _VALID_TIMINGS:
+            valid = ", ".join(sorted(_VALID_TIMINGS))
+            raise ValueError(
+                f"timing must be one of {{{valid}}}; got {self.timing!r}."
+            )
+        if not (
+            callable(self.forcing_object)
+            or hasattr(self.forcing_object, "get_forcing")
+        ):
+            raise TypeError(
+                "forcing_object must be callable or have a get_forcing method."
+            )
+
+    def evaluate(self, t):
+        """Return the forcing value at time ``t``."""
+        if hasattr(self.forcing_object, "get_forcing"):
+            return self.forcing_object.get_forcing(t)
+        return self.forcing_object(t)
+
+
 __all__ = [
     "ResolvedSegment",
     "ForcingElement",
@@ -533,4 +599,5 @@ __all__ = [
     "Harmonic",
     "ForcingSequence",
     "Forcing",
+    "ForcingSpec",
 ]

--- a/paleobeasts/core/pbmodel.py
+++ b/paleobeasts/core/pbmodel.py
@@ -8,29 +8,46 @@ from ..utils.solver import (euler_method, euler_maruyama_method, rk4_method, Sol
                             validate_initial_state as _validate_initial_state,
                             build_state_from_history as _build_state_from_history)
 from .pboutput import PBOutput
+from .forcing import ForcingSpec
 
 
 class PBModel:
-    '''The overarching model structure for Paleobeasts. 
-    
-    PBModel serves as the archetype/parent class for models within the signal_models directory.
-    This class is not meant to be instantiated, but rather to be inherited by other classes.
+    """The overarching model structure for PaleoBeasts.
+
+    PBModel serves as the archetype/parent class for models within the
+    ``signal_models`` directory.  It is not meant to be instantiated directly.
 
     Parameter handling
     ------------------
-    Models may define a ``param_values`` dict that maps parameter names to either:
-    - constants (floats/ints)
-    - callables (time/state/model aware)
-    - objects with ``get_forcing`` (e.g., ``pb.core.Forcing``)
+    Models may define a ``param_values`` dict that maps parameter names to
+    constants, callables, or ``Forcing`` objects.  Use
+    ``get_param_value(name, t, state)`` inside ``dydt`` to resolve any of these
+    uniformly.
 
-    Use ``get_param(name, t, state)`` inside ``dydt`` to resolve time-varying parameters.
-    
-    '''
+    To make a parameter state- or time-dependent after construction, assign a
+    callable via ``set_param_value``::
+
+        model.set_param_value('rho', lambda t, state: 28.0 + 0.1 * state[0])
+
+    To replace a *computation method* (e.g. ``calc_albedo``) on a single
+    instance without subclassing, use ``set_function``.
+
+    External forcings
+    -----------------
+    Use ``register_forcing`` to attach a time-varying external driver to any
+    named parameter or state variable after construction::
+
+        model.register_forcing('S0', forcing_obj)                         # parameter
+        model.register_forcing('x', forcing_obj, 'additive', timing='pre')  # state
+
+    See ``register_forcing`` for the full contract and default timing rules.
+    """
 
     def __init__(self, forcing, variable_name, state_variables=None, non_integrated_state_vars=None,
                  diagnostic_variables=None):
         self.variable_name = variable_name
         self.forcing = forcing
+        self._forcings: dict = {}
 
         if state_variables is None:
             state_variables = []
@@ -76,11 +93,14 @@ class PBModel:
         A plain shallow copy would share the ``diagnostic_variables`` lists
         between the original and the copy, so appends during integration would
         corrupt both.  Resetting them here ensures a copied model starts with
-        no accumulated output from the original's run.
+        no accumulated output from the original's run.  The ``_forcings``
+        registry is copied shallowly so the copy shares the same
+        ``ForcingSpec`` objects (they are immutable).
         """
         new_obj = type(self)(self.forcing, self.variable_name)
         new_obj.__dict__.update(self.__dict__)
         new_obj.diagnostic_variables = {var: [] for var in self.diagnostic_variables}
+        new_obj._forcings = {k: list(v) for k, v in self._forcings.items()}
         return new_obj
 
     def _resolve_param(self, param, t, state):
@@ -245,7 +265,146 @@ class PBModel:
         setattr(self, name, replacement)
         return getattr(self, name)
 
+    def register_forcing(self, var_name: str, forcing_object, attachment_style: str = None,
+                         timing: str = None):
+        """Attach an external forcing to a named parameter or state variable.
 
+        Parameters
+        ----------
+        var_name : str
+            Name of the target.  Must exist in ``param_values`` (parameter
+            namespace) or ``state_variables_names`` (state namespace).  If the
+            name appears in both, a ``ValueError`` is raised — this is a model
+            design issue worth resolving explicitly.
+        forcing_object :
+            A ``Forcing`` instance, a callable ``f(t)`` → scalar/array, or any
+            object with a ``get_forcing(t)`` method.
+        attachment_style : {"replacement", "additive"}, optional
+            How the forcing value is applied.
+
+            * Parameters default to ``"replacement"`` (the only meaningful
+              operation: a parameter has no dynamics of its own).
+            * State variables have **no default** — ``attachment_style`` is
+              required.  This is intentional: injecting into a live state
+              variable is a significant physical choice that should be explicit.
+        timing : {"pre", "post"}, optional
+            When the forcing is applied relative to the integration step.
+            Derived automatically in most cases:
+
+            * parameter + replacement → ``"pre"`` (always; no override)
+            * state + replacement     → ``"post"`` (always; warns if ``"pre"`` passed)
+            * state + additive        → **required**; raise if not provided
+
+        Raises
+        ------
+        ValueError
+            If ``var_name`` is not found, if ``attachment_style`` is missing for
+            a state variable, if ``timing`` is missing for state + additive, or
+            if a second ``"replacement"`` is registered on the same variable.
+        """
+        in_params = var_name in self.param_values
+        in_state = var_name in self.state_variables_names
+
+        if in_params and in_state:
+            raise ValueError(
+                f"'{var_name}' appears in both param_values and state_variables_names. "
+                "Resolve this ambiguity in the model definition before registering a forcing."
+            )
+        if not in_params and not in_state:
+            valid = sorted(list(self.param_values.keys()) + list(self.state_variables_names))
+            raise ValueError(
+                f"'{var_name}' not found in this model's parameters or state variables. "
+                f"Valid names: {valid}"
+            )
+
+        if in_params:
+            if attachment_style is None:
+                attachment_style = "replacement"
+            if attachment_style != "replacement":
+                raise ValueError(
+                    f"Parameters only support attachment_style='replacement'; "
+                    f"got {attachment_style!r} for '{var_name}'."
+                )
+            resolved_timing = "pre"
+            if timing is not None and timing != "pre":
+                raise ValueError(
+                    f"Parameter forcings are always applied pre-step; "
+                    f"timing='{timing}' is not valid for '{var_name}'."
+                )
+
+        else:  # state variable
+            if attachment_style is None:
+                raise ValueError(
+                    f"attachment_style is required when forcing a state variable ('{var_name}'). "
+                    "Choose 'replacement' (post-step correction to x) or "
+                    "'additive' (pre- or post-step injection — specify timing)."
+                )
+            if attachment_style == "replacement":
+                if timing is not None and timing != "post":
+                    warnings.warn(
+                        f"State variable replacement is always applied post-step. "
+                        f"Ignoring timing='{timing}' for '{var_name}'.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                resolved_timing = "post"
+            elif attachment_style == "additive":
+                if timing is None:
+                    raise ValueError(
+                        f"timing is required for additive state forcing on '{var_name}'. "
+                        "Choose 'pre' (adds to dx/dt inside the RHS) or "
+                        "'post' (adds to x after each integration step)."
+                    )
+                resolved_timing = timing
+            else:
+                raise ValueError(
+                    f"attachment_style must be 'replacement' or 'additive'; "
+                    f"got {attachment_style!r}."
+                )
+
+        # conflict check: two replacements on the same variable
+        existing = self._forcings.get(var_name, [])
+        if attachment_style == "replacement" and any(
+            s.attachment_style == "replacement" for s in existing
+        ):
+            raise ValueError(
+                f"A replacement forcing is already registered for '{var_name}'. "
+                "Remove it before registering another, or use attachment_style='additive'."
+            )
+
+        spec = ForcingSpec(
+            forcing_object=forcing_object,
+            attachment_style=attachment_style,
+            timing=resolved_timing,
+        )
+        self._forcings.setdefault(var_name, []).append(spec)
+
+    def get_forcings(self, var_name: str = None):
+        """Return registered forcings, optionally filtered by variable name.
+
+        Parameters
+        ----------
+        var_name : str, optional
+            If given, return the list of ``ForcingSpec`` objects for that
+            variable.  If omitted, return the full ``_forcings`` dict.
+        """
+        if var_name is None:
+            return dict(self._forcings)
+        return list(self._forcings.get(var_name, []))
+
+    def clear_forcings(self, var_name: str = None):
+        """Remove registered forcings.
+
+        Parameters
+        ----------
+        var_name : str, optional
+            If given, clear only the forcings for that variable.
+            If omitted, clear all forcings on the model.
+        """
+        if var_name is None:
+            self._forcings.clear()
+        else:
+            self._forcings.pop(var_name, None)
 
     def dydt(self, t, y):
         """Define the system of differential equations.

--- a/paleobeasts/core/pbmodel.py
+++ b/paleobeasts/core/pbmodel.py
@@ -43,10 +43,9 @@ class PBModel:
     See ``register_forcing`` for the full contract and default timing rules.
     """
 
-    def __init__(self, forcing, variable_name, state_variables=None, non_integrated_state_vars=None,
+    def __init__(self, variable_name, state_variables=None, non_integrated_state_vars=None,
                  diagnostic_variables=None):
         self.variable_name = variable_name
-        self.forcing = forcing
         self._forcings: dict = {}
 
         if state_variables is None:
@@ -90,14 +89,12 @@ class PBModel:
     def __copy__(self):
         """Shallow copy with diagnostic variables reset to empty lists.
 
-        A plain shallow copy would share the ``diagnostic_variables`` lists
-        between the original and the copy, so appends during integration would
-        corrupt both.  Resetting them here ensures a copied model starts with
-        no accumulated output from the original's run.  The ``_forcings``
-        registry is copied shallowly so the copy shares the same
-        ``ForcingSpec`` objects (they are immutable).
+        Uses ``object.__new__`` rather than calling the constructor so that
+        subclass ``__init__`` signatures don't need to be reproduced here.
+        ``_forcings`` lists are copied shallowly — the ``ForcingSpec`` objects
+        themselves are shared (they carry no mutable state).
         """
-        new_obj = type(self)(self.forcing, self.variable_name)
+        new_obj = object.__new__(type(self))
         new_obj.__dict__.update(self.__dict__)
         new_obj.diagnostic_variables = {var: [] for var in self.diagnostic_variables}
         new_obj._forcings = {k: list(v) for k, v in self._forcings.items()}
@@ -161,19 +158,6 @@ class PBModel:
         return param(t, state, self)
 
 
-
-    def resolve_forcing(self, t, default=0.0):
-        """Evaluate the model's external forcing at time t.
-
-        If no forcing object is attached (``self.forcing is None``), returns
-        ``default``, which the caller supplies — a fallback parameter value, a
-        zero vector, or a computed internal term.  Keeping the fallback out of
-        this method preserves the distinction between forcings (external drivers)
-        and parameters (intrinsic model properties).
-        """
-        if self.forcing is None:
-            return default
-        return self.forcing.get_forcing(self.time_util(t))
 
     def get_param_value(self, name, t, state):
         """Resolve a named parameter to its value at the current time and state.
@@ -406,6 +390,96 @@ class PBModel:
         else:
             self._forcings.pop(var_name, None)
 
+    # ------------------------------------------------------------------
+    # Forcing application helpers
+    # ------------------------------------------------------------------
+
+    _FIXED_STEP_METHODS = {"euler", "euler_maruyama", "rk4"}
+
+    def _build_forced_dydt(self):
+        """Return a wrapped dydt that applies all pre-step forcings.
+
+        For parameter replacement forcings: temporarily patches ``param_values``
+        before calling the original ``dydt``, then restores it.  This means
+        ``get_param_value`` inside ``dydt`` transparently sees the forced value
+        without any changes to subclass code.
+
+        For state additive forcings: adds the forcing value to the appropriate
+        index of the returned dxdt vector after the original ``dydt`` returns.
+
+        Returns the original ``dydt`` unchanged if no pre-step forcings are
+        registered, so the caller can always substitute the result.
+        """
+        pre_param = []   # [(var_name, spec), ...]
+        pre_state = []   # [(idx, spec), ...]
+
+        for var_name, specs in self._forcings.items():
+            for spec in specs:
+                if spec.timing != "pre":
+                    continue
+                if var_name in self.param_values:
+                    pre_param.append((var_name, spec))
+                elif var_name in self.integrated_state_vars:
+                    idx = self.integrated_state_vars.index(var_name)
+                    pre_state.append((idx, spec))
+
+        if not pre_param and not pre_state:
+            return self.dydt
+
+        original_dydt = self.dydt
+
+        def forced_dydt(t, x, *args):
+            saved = {}
+            for var_name, spec in pre_param:
+                saved[var_name] = self.param_values[var_name]
+                self.param_values[var_name] = spec.evaluate(self.time_util(t))
+
+            dxdt = np.asarray(original_dydt(t, x, *args), dtype=float).copy()
+
+            for var_name, original_val in saved.items():
+                self.param_values[var_name] = original_val
+
+            for idx, spec in pre_state:
+                dxdt[idx] += spec.evaluate(self.time_util(t))
+
+            return dxdt
+
+        return forced_dydt
+
+    def _build_post_step(self):
+        """Return a post-step callback for all post-step forcings, or None.
+
+        The callback has signature ``post_step(t, y) -> y`` and is intended
+        for the fixed-step solvers.  It applies replacement and additive
+        forcings in registration order for each variable.
+
+        Returns ``None`` if no post-step forcings are registered.
+        """
+        post_forcings = []  # [(idx, spec), ...]
+
+        for var_name, specs in self._forcings.items():
+            if var_name not in self.integrated_state_vars:
+                continue
+            idx = self.integrated_state_vars.index(var_name)
+            for spec in specs:
+                if spec.timing == "post":
+                    post_forcings.append((idx, spec))
+
+        if not post_forcings:
+            return None
+
+        def post_step(t, y):
+            y = np.asarray(y, dtype=float).copy()
+            for idx, spec in post_forcings:
+                val = spec.evaluate(self.time_util(t))
+                if spec.attachment_style == "replacement":
+                    y[idx] = val
+                else:
+                    y[idx] += val
+            return y
+
+        return post_step
+
     def dydt(self, t, y):
         """Define the system of differential equations.
 
@@ -490,11 +564,26 @@ class PBModel:
             else np.array(self.y0, dtype=dtype)
         )
 
+        # --- build forcing wrappers ---
+        dydt_fn = self._build_forced_dydt()
+        post_step = self._build_post_step()
+
+        if post_step is not None and method not in self._FIXED_STEP_METHODS:
+            warnings.warn(
+                f"Post-step forcings are registered but method='{method}' is adaptive. "
+                "Post-step forcings will not be applied during integration. "
+                "Use a fixed-step method ('euler', 'rk4', 'euler_maruyama') to apply them.",
+                UserWarning,
+                stacklevel=2,
+            )
+            post_step = None
+
         # --- run solver ---
         y0_integrated = y0[:len(self.integrated_state_vars)]
 
         if method == 'euler':
-            solution = euler_method(self.dydt, t_span, y0_integrated, dt, args=self.params)
+            solution = euler_method(dydt_fn, t_span, y0_integrated, dt,
+                                    args=self.params, post_step=post_step)
 
         elif method == 'euler_maruyama':
             seed = kwargs.pop('random_seed', None)
@@ -503,8 +592,9 @@ class PBModel:
             if not callable(noise_func):
                 noise_func = lambda _t, x: np.zeros_like(np.asarray(x, dtype=float))
             solution = euler_maruyama_method(
-                self.dydt, t_span, y0_integrated, dt,
+                dydt_fn, t_span, y0_integrated, dt,
                 noise_func=noise_func, rng=self.rng, args=self.params,
+                post_step=post_step,
             )
 
         elif method == 'rk4':
@@ -513,12 +603,13 @@ class PBModel:
                     "method='rk4' requires uses_post_history = True on the subclass."
                 )
             si = float(kwargs.pop('si', dt))
-            solution = rk4_method(self.dydt, t_span, y0_integrated, dt, si=si, args=self.params)
+            solution = rk4_method(dydt_fn, t_span, y0_integrated, dt, si=si,
+                                  args=self.params, post_step=post_step)
 
         else:  # scipy solve_ivp
             kwargs.setdefault('dense_output', True)
             solution = solve_ivp(
-                self.dydt, t_span, y0_integrated,
+                dydt_fn, t_span, y0_integrated,
                 method=method, args=self.params,
                 **kwargs,
             )

--- a/paleobeasts/signal_models/box_model.py
+++ b/paleobeasts/signal_models/box_model.py
@@ -375,18 +375,17 @@ class BoxModelSpec:
         if missing:
             raise ValueError(f"Missing tendency relations for state variables: {missing}")
 
-    def make_model(self, forcing=None, var_name=None, **parameter_overrides):
+    def make_model(self, var_name=None, **parameter_overrides):
         """Instantiate a :class:`GenericBoxModel` from this spec."""
         self.validate()
         return GenericBoxModel(
             self,
-            forcing=forcing,
             var_name=var_name if var_name is not None else self.name,
             **parameter_overrides,
         )
 
-    def make_boxmodel(self, forcing=None, var_name=None, **parameter_overrides):
-        return self.make_model(forcing=forcing, var_name=var_name, **parameter_overrides)
+    def make_boxmodel(self, var_name=None, **parameter_overrides):
+        return self.make_model(var_name=var_name, **parameter_overrides)
 
 
 class GenericBoxModel(PBModel):
@@ -412,14 +411,13 @@ class GenericBoxModel(PBModel):
         ``spec.parameter_defaults``.
     """
 
-    def __init__(self, spec, forcing=None, var_name=None, *args, **kwargs):
+    def __init__(self, spec, var_name=None, *args, **kwargs):
         self.spec = spec
         kwargs.pop("parameter_contract", None)
         param_values = dict(spec.parameter_defaults)
         param_values.update(kwargs)
 
         super().__init__(
-            forcing=forcing,
             variable_name=var_name if var_name is not None else spec.name,
             state_variables=list(spec.state_variables),
             diagnostic_variables=list(spec.diagnostic_variables),
@@ -436,25 +434,19 @@ class GenericBoxModel(PBModel):
         return True
 
     def resolve_input(self, name, t, state):
-        """Resolve a registered input from forcing or fallback parameter."""
+        """Resolve a registered input from its fallback parameter.
+
+        To drive an input with a time-varying external signal, register a
+        forcing on the corresponding fallback parameter::
+
+            model.register_forcing('fallback_param_name', forcing_obj)
+        """
         if name not in self.spec.input_specs:
             raise KeyError(f"Input '{name}' is not registered on this BoxModelSpec.")
 
         input_spec = self.spec.input_specs[name]
-        if self.forcing is not None:
-            value = self.forcing.get_forcing(self.time_util(t))
-            if len(self.spec.input_specs) == 1:
-                return value
-            if isinstance(value, dict):
-                if name not in value:
-                    raise KeyError(f"Forcing dict does not include input '{name}'.")
-                return value[name]
-            raise ValueError(
-                "Multi-input generic box models require forcing values to be dict-like."
-            )
-
         if input_spec.fallback_param is None:
-            raise ValueError(f"Input '{name}' has no forcing and no fallback parameter.")
+            raise ValueError(f"Input '{name}' has no fallback parameter defined.")
         return self.get_param_value(input_spec.fallback_param, t, state)
 
     def resolve_box_volume(self, name, t, state):

--- a/paleobeasts/signal_models/box_model.py
+++ b/paleobeasts/signal_models/box_model.py
@@ -401,9 +401,6 @@ class GenericBoxModel(PBModel):
     ----------
     spec : BoxModelSpec
         The validated specification object.
-    forcing : pb.core.Forcing or None
-        Optional external forcing passed through to registered input
-        channels.  Default ``None``.
     var_name : str or None
         Override for the model name.  Defaults to ``spec.name``.
     kwargs : dict

--- a/paleobeasts/signal_models/daisyworld.py
+++ b/paleobeasts/signal_models/daisyworld.py
@@ -20,8 +20,6 @@ class Daisyworld(PBModel):
 
     Parameters
     ----------
-    forcing : pb.core.Forcing or None
-        Optional luminosity perturbation added to ``L``.  Default ``None``.
     var_name : str
         Label for the model output.  Default ``'daisyworld'``.
     alpha_w : float or callable or pb.core.Forcing
@@ -42,6 +40,8 @@ class Daisyworld(PBModel):
         Solar constant (W m\ :sup:`-2`).  Default 1365.0.
     L : float or callable or pb.core.Forcing
         Normalized stellar luminosity (1.0 = present Sun).  Default 1.0.
+        Register a time-varying luminosity via
+        ``model.register_forcing('L', forcing_obj)``.
     C : float or callable or pb.core.Forcing
         Planetary heat capacity (effective, in model units).  Default 10.0.
     sigma : float or callable or pb.core.Forcing

--- a/paleobeasts/signal_models/daisyworld.py
+++ b/paleobeasts/signal_models/daisyworld.py
@@ -71,7 +71,7 @@ class Daisyworld(PBModel):
     from paleobeasts.signal_models.daisyworld import Daisyworld
     import matplotlib.pyplot as plt
 
-    model = Daisyworld(forcing=None, L=0.9)
+    model = Daisyworld(L=0.9)
     output = model.integrate(
         t_span=(0, 500), y0=[0.2, 0.2, 295.0], method='RK45'
     )
@@ -83,7 +83,7 @@ class Daisyworld(PBModel):
     
     """
 
-    def __init__(self, forcing=None, var_name='daisyworld', alpha_w=0.75, alpha_b=0.25, alpha_g=0.5,
+    def __init__(self, var_name='daisyworld', alpha_w=0.75, alpha_b=0.25, alpha_g=0.5,
                  gamma=0.3, q=20.0, T_opt=295.0, beta_width=0.003265, S0=1365.0, L=1.0, C=10.0,
                  sigma=5.67051196e-8, state_variables=None, diagnostic_variables=None, *args, **kwargs):
         if state_variables is None:
@@ -91,7 +91,7 @@ class Daisyworld(PBModel):
         if diagnostic_variables is None:
             diagnostic_variables = ['A_planet', 'A_bare', 'beta_w', 'beta_b']
 
-        super().__init__(forcing, var_name, state_variables=state_variables,
+        super().__init__(var_name, state_variables=state_variables,
                          diagnostic_variables=diagnostic_variables, *args, **kwargs)
 
         self.alpha_w = alpha_w
@@ -121,10 +121,7 @@ class Daisyworld(PBModel):
         self.params = ()
 
     def _luminosity(self, t, x):
-        L_base = self.get_param_value('L', t, x)
-        if self.forcing is None:
-            return L_base
-        return L_base + self.forcing.get_forcing(self.time_util(t))
+        return self.get_param_value('L', t, x)
 
     def _growth(self, T_local, t, x):
         T_opt = self.get_param_value('T_opt', t, x)

--- a/paleobeasts/signal_models/damped_spring.py
+++ b/paleobeasts/signal_models/damped_spring.py
@@ -10,10 +10,6 @@ class DampedSpring(PBModel):
 
     Parameters
     ----------
-    forcing:
-        Optional external driving force F(t).  Pass a ``Forcing`` object;
-        ``get_forcing(t)`` should return force in Newtons.  If ``None``,
-        the undriven damped oscillator is simulated.
     var_name:
         Human-readable label for the model.
     m:
@@ -23,16 +19,27 @@ class DampedSpring(PBModel):
     c:
         Linear damping coefficient in N·s/m.  ``c=0`` gives undamped SHM;
         ``c < 2*sqrt(k*m)`` gives underdamped (oscillatory) decay.
+    F : float or callable or pb.core.Forcing
+        External driving force (N).  Default 0.0 (undriven).  For a
+        time-varying drive use ``model.register_forcing('F', forcing_obj)``.
     state_variables:
         Names for the two integrated state variables (position, velocity).
     diagnostic_variables:
         Names for post-integration diagnostics.
 
+    Notes
+    -----
+    State variables are ``x`` (position) and ``v`` (velocity) in that order.
+    Diagnostic variables ``energy`` and ``omega_0`` are computed after
+    integration.
+
     Examples
     --------
 
     ```python
+    import numpy as np
     import matplotlib.pyplot as plt
+    import paleobeasts as pb
     from paleobeasts.signal_models.damped_spring import DampedSpring
 
     model = DampedSpring(m=1.0, k=4.0, c=0.4)
@@ -41,6 +48,16 @@ class DampedSpring(PBModel):
     ts.plot()
     plt.savefig('docs/reference/figures/DampedSpring_example.png',
                 dpi=150, bbox_inches='tight')
+    ```
+
+    With resonant driving (external force at ω₀):
+
+    ```python
+    m, k = 1.0, 4.0
+    omega_0 = np.sqrt(k / m)
+    model = DampedSpring(m=m, k=k, c=0.0)
+    model.register_forcing('F', pb.core.Forcing(lambda t: np.cos(omega_0 * t)))
+    output = model.integrate(t_span=(0, 30), y0=[0.0, 0.0], method='RK45')
     ```
 
     """

--- a/paleobeasts/signal_models/damped_spring.py
+++ b/paleobeasts/signal_models/damped_spring.py
@@ -35,7 +35,7 @@ class DampedSpring(PBModel):
     import matplotlib.pyplot as plt
     from paleobeasts.signal_models.damped_spring import DampedSpring
 
-    model = DampedSpring(forcing=None, m=1.0, k=4.0, c=0.4)
+    model = DampedSpring(m=1.0, k=4.0, c=0.4)
     output = model.integrate(t_span=(0, 30), y0=[1.0, 0.0], method='RK45')
     ts = output.to_pyleo(var_names=['x'])
     ts.plot()
@@ -47,11 +47,11 @@ class DampedSpring(PBModel):
 
     def __init__(
         self,
-        forcing=None,
         var_name="damped_spring",
         m=1.0,
         k=1.0,
         c=0.1,
+        F=0.0,
         state_variables=None,
         diagnostic_variables=None,
         *args,
@@ -63,7 +63,6 @@ class DampedSpring(PBModel):
             diagnostic_variables = ["energy", "omega_0"]
 
         super().__init__(
-            forcing,
             var_name,
             state_variables=state_variables,
             diagnostic_variables=diagnostic_variables,
@@ -74,10 +73,12 @@ class DampedSpring(PBModel):
         self.m = m
         self.k = k
         self.c = c
+        self.F = F
         self.param_values = {
             "m": m,
             "k": k,
             "c": c,
+            "F": F,
         }
         self.params = ()
 
@@ -100,7 +101,7 @@ class DampedSpring(PBModel):
         if k <= 0.0:
             raise ValueError("k must be > 0.")
 
-        F = float(self.resolve_forcing(t))
+        F = float(self.get_param_value("F", t, state))
 
         dxdt = vel
         dvdt = -(c / m) * vel - (k / m) * pos + F / m

--- a/paleobeasts/signal_models/ebm.py
+++ b/paleobeasts/signal_models/ebm.py
@@ -639,6 +639,9 @@ class EBM1DLat(EBMBase):
                 continue
 
             cold_idx = np.where(temp_side <= threshold)[0][0]
+            if cold_idx == 0:
+                hemi_edges.append(0.0)
+                continue
             warm_idx = cold_idx - 1
             t_warm = temp_side[warm_idx]
             t_cold = temp_side[cold_idx]

--- a/paleobeasts/signal_models/ebm.py
+++ b/paleobeasts/signal_models/ebm.py
@@ -179,13 +179,11 @@ class EBM0D(EBMBase):
 
         C dT/dt = (1 - alpha) * S0/4 - OLR
 
-    where S0 is the solar constant supplied by ``forcing``, ``alpha`` is the
-    planetary albedo, and OLR is the outgoing longwave radiation.
+    where ``S0`` is the solar constant, ``alpha`` is the planetary albedo,
+    and OLR is the outgoing longwave radiation.
 
     Parameters
     ----------
-    forcing : pb.core.Forcing
-        Provides the solar constant S0 (W m⁻²) as a function of time.
     state_variables : list of str, optional
         Names of the integrated state variables.  Default is ``['T']``.
     diagnostic_variables : list of str, optional
@@ -205,15 +203,18 @@ class EBM0D(EBMBase):
     albedo : float or callable or pb.core.Forcing, optional
         Planetary albedo.  If callable, must follow the parameter callable
         contract.  Default is 0.3.
+    S0 : float or callable or pb.core.Forcing, optional
+        Solar constant (W m⁻²).  Default 1365.0.  Pass a time-varying
+        orbital signal via ``model.register_forcing('S0', forcing_obj)``.
 
     Notes
     -----
-    All parameters that support callables or Forcing objects are registered
-    in ``param_values`` (``'C'``, ``'albedo'``, ``'OLR'``) and resolved
-    at each timestep via ``get_param_value``.
+    State variable is ``T`` (global-mean surface temperature, K).  Diagnostic
+    variables ``albedo``, ``absorbed_SW``, ``OLR``, and ``solar_incoming``
+    are accumulated step-by-step during integration.
 
-    This model uses ``uses_post_history = False``: state and diagnostics are
-    accumulated step-by-step inside ``dydt``.
+    All parameters support time-varying callables or Forcing objects;
+    they are resolved at each timestep via ``get_param_value``.
 
     See also
     --------
@@ -327,9 +328,6 @@ class EBM1DLat(EBMBase):
 
     Parameters
     ----------
-    forcing : pb.core.Forcing or None, optional
-        Reserved for future use (e.g. external orbital forcing).
-        Default is None; solar input is controlled by ``S0`` instead.
     var_name : str, optional
         Label for the modeled quantity.  Default is ``'ebm1d_lat'``.
     grid_n : int, optional
@@ -357,17 +355,17 @@ class EBM1DLat(EBMBase):
 
     Notes
     -----
-    ``uses_post_history = True``: state variables and diagnostics are derived
-    from the full solved trajectory in ``populate_diagnostics_from_history``
-    rather than accumulated step-by-step in ``dydt``.
+    State variables are ``T_0`` through ``T_{grid_n-1}`` (one temperature per
+    latitude band, ordered from south pole to north pole).  Diagnostic
+    variables ``ice_line_lat`` and ``Tglobal`` are derived after integration.
 
     ``validate_initial_state`` accepts a scalar and broadcasts it uniformly
     to the full grid.
 
     All parameters (``C``, ``D``, ``A``, ``B``, ``S0``, ``CO2_forcing``) are
     registered in ``param_values`` and can be swapped for callables or
-    Forcing objects at any time.  Callables must follow the contract in
-    ``contracts/signal_model_contract.md``.
+    Forcing objects.  Callables must follow the contract ``(t)``,
+    ``(t, state)``, or ``(t, state, model)``.
 
     See also
     --------

--- a/paleobeasts/signal_models/ebm.py
+++ b/paleobeasts/signal_models/ebm.py
@@ -229,8 +229,7 @@ class EBM0D(EBMBase):
     import paleobeasts as pb
     from paleobeasts.signal_models.ebm import EBM0D
 
-    forcing = pb.core.Forcing(lambda t: 1360.0)
-    model = EBM0D(forcing=forcing)
+    model = EBM0D(S0=1360.0)
     output = model.integrate(t_span=(0, 500), y0=[288.0], method='RK45')
     ts = output.to_pyleo(var_names=['T'])
     ts.plot()
@@ -243,32 +242,30 @@ class EBM0D(EBMBase):
     ```python
     from paleobeasts.signal_models.ebm import EBM0D, albedo_func, OLR_func
 
-    model = EBM0D(
-        forcing=forcing,
-        albedo=albedo_func,
-        OLR=OLR_func(pRad=600),
-    )
+    model = EBM0D(albedo=albedo_func, OLR=OLR_func(pRad=600))
     ```
 
     """
 
-    def __init__(self, forcing, var_name='temperature', state_variables=None,
-                 diagnostic_variables=None, OLR=None, C=4, albedo=0.3):
+    def __init__(self, var_name='temperature', state_variables=None,
+                 diagnostic_variables=None, OLR=None, C=4, albedo=0.3, S0=1365.0):
         if state_variables is None:
             state_variables = ['T']
         if diagnostic_variables is None:
             diagnostic_variables = ['albedo', 'absorbed_SW', 'OLR', 'solar_incoming']
 
-        super().__init__(forcing, var_name, state_variables=state_variables,
+        super().__init__(var_name, state_variables=state_variables,
                          diagnostic_variables=diagnostic_variables)
 
         self.C = C
         self.albedo = albedo
+        self.S0 = S0
         self.OLR = OLR if OLR is not None else OLR_func()
         self.param_values = {
             'C': self.C,
             'albedo': self.albedo,
             'OLR': self.OLR,
+            'S0': S0,
         }
         self.params = ()
 
@@ -293,7 +290,7 @@ class EBM0D(EBMBase):
         """
         T = float(x[0])
 
-        f_solar_incoming = self.resolve_forcing(t)
+        f_solar_incoming = self.get_param_value('S0', t, x)
         albedo = self.calc_albedo(T, t)
         absorbed_SW = (1 - albedo) * f_solar_incoming / 4
         OLR = self.calc_OLR(T, t)
@@ -387,7 +384,7 @@ class EBM1DLat(EBMBase):
     from paleobeasts.signal_models.ebm import EBM1DLat
 
     grid_n = 50
-    model = EBM1DLat(forcing=None, S0=1365.0, grid_n=grid_n)
+    model = EBM1DLat(S0=1365.0, grid_n=grid_n)
     output = model.integrate(
         t_span=(0, 200), y0=np.full(grid_n, 15.0), method='rk4', dt=1.0
     )
@@ -410,7 +407,7 @@ class EBM1DLat(EBMBase):
         pb.core.Hold(duration=100, value=0.0),
         pb.core.Ramp(duration=100, y0=0.0, yf=4.0, shape='linear'),
     ])
-    model = EBM1DLat(forcing=None, CO2_forcing=co2_ramp)
+    model = EBM1DLat(CO2_forcing=co2_ramp)
     output = model.integrate(t_span=(0, 200), y0=[15.0], method='rk4', dt=1.0)
     ```
 
@@ -418,7 +415,7 @@ class EBM1DLat(EBMBase):
 
     uses_post_history = True
 
-    def __init__(self, forcing=None, var_name='ebm1d_lat', grid_n=50, C=10.0, D=0.55,
+    def __init__(self, var_name='ebm1d_lat', grid_n=50, C=10.0, D=0.55,
                  A=210.0, B=2.0, S0=1365.0, CO2_forcing=0.0,
                  state_variables=None, diagnostic_variables=None):
         self.grid_n = int(grid_n)
@@ -433,7 +430,7 @@ class EBM1DLat(EBMBase):
         if diagnostic_variables is None:
             diagnostic_variables = ['ice_line_lat', 'Tglobal']
 
-        super().__init__(forcing, var_name, state_variables=state_variables,
+        super().__init__(var_name, state_variables=state_variables,
                          diagnostic_variables=diagnostic_variables)
 
         self.C = C

--- a/paleobeasts/signal_models/enso_recharge.py
+++ b/paleobeasts/signal_models/enso_recharge.py
@@ -5,6 +5,39 @@ import numpy as np
 from paleobeasts.core.pbmodel import PBModel
 
 
+def seasonal_forcing(t, Af=0.5, Pf=6.0):
+    """Standard sinusoidal seasonal forcing for the ENSO recharge oscillator.
+
+    Returns the seasonal SST forcing term ``Af * sin(2π t / Pf)``, which can
+    be wrapped in a ``Forcing`` object and registered on the model::
+
+        import paleobeasts as pb
+        from paleobeasts.signal_models.enso_recharge import (
+            ENSORechargeOscillator, seasonal_forcing)
+        from functools import partial
+
+        model = ENSORechargeOscillator()
+        sf = partial(seasonal_forcing, Af=0.5, Pf=6.0)
+        model.register_forcing('T', pb.core.Forcing(sf),
+                               attachment_style='additive', timing='pre')
+
+    Parameters
+    ----------
+    t : float
+        Time (model units, e.g. months).
+    Af : float
+        Seasonal forcing amplitude.  Default 0.5.
+    Pf : float
+        Seasonal forcing period (same units as ``t``).  Default 6.0.
+
+    Returns
+    -------
+    float
+        Seasonal forcing value at time ``t``.
+    """
+    return Af * np.sin(2.0 * np.pi * t / Pf)
+
+
 class ENSORechargeOscillator(PBModel):
     """Jin-style ENSO recharge oscillator.
 
@@ -16,12 +49,20 @@ class ENSORechargeOscillator(PBModel):
 
     where ``b = b0*mu`` and ``R = gamma*b - c``.
 
+    By default ``Af=0`` so the model runs without any seasonal forcing.
+    To add the standard seasonal cycle, register it externally::
+
+        from functools import partial
+        sf = partial(seasonal_forcing, Af=0.5, Pf=6.0)
+        model.register_forcing('T', pb.core.Forcing(sf),
+                               attachment_style='additive', timing='pre')
+
+    Alternatively, set ``Af`` to a non-zero value to drive seasonal forcing
+    internally through the ``_sst_forcing`` helper without registering an
+    external forcing.
+
     Parameters
     ----------
-    forcing : pb.core.Forcing or None
-        External forcing used in ``dT/dt``. If provided it replaces the
-        internal seasonal term ``Af*sin(2*pi*t/Pf)`` entirely. Default
-        ``None``.
     var_name : str
         Label for the model output.  Default ``'enso_recharge_oscillator'``.
     mu : float or callable or pb.core.Forcing
@@ -29,11 +70,9 @@ class ENSORechargeOscillator(PBModel):
     en : float or callable or pb.core.Forcing
         Nonlinear damping coefficient.  Default 0.0 (linear limit).
     Af : float or callable or pb.core.Forcing
-        Seasonal forcing amplitude used only when ``forcing`` is ``None``.
-        Default 0.0.
+        Internal seasonal forcing amplitude.  Default 0.0 (no seasonal forcing).
     Pf : float or callable or pb.core.Forcing
-        Seasonal forcing period (model time units), used only when
-        ``forcing`` is ``None``. Default 6.0.
+        Internal seasonal forcing period (model time units).  Default 6.0.
     c : float or callable or pb.core.Forcing
         Newtonian cooling rate of SST.  Default 1.0.
     r : float or callable or pb.core.Forcing
@@ -51,8 +90,8 @@ class ENSORechargeOscillator(PBModel):
     this is baked in but does not affect ``t`` directly as the equations are
     already in the dimensionless form used in the worksheet.
 
-    State variables are ``T`` and ``h`` in that order. ``Pf`` must be
-    non-zero when the internal seasonal forcing is used (raises
+    State vector: ``[T, h]`` — eastern Pacific SST anomaly and thermocline
+    depth anomaly.  ``Pf`` must be non-zero when ``Af != 0`` (raises
     ``ValueError`` otherwise).
 
     References
@@ -66,7 +105,7 @@ class ENSORechargeOscillator(PBModel):
     import matplotlib.pyplot as plt
     from paleobeasts.signal_models.enso_recharge import ENSORechargeOscillator
 
-    model = ENSORechargeOscillator(forcing=None, mu=0.75, Af=0.5, Pf=6.0)
+    model = ENSORechargeOscillator(mu=0.75, Af=0.5, Pf=6.0)
     output = model.integrate(
         t_span=(0, 120), y0=[0.5, 0.0], method='RK45'
     )
@@ -79,7 +118,6 @@ class ENSORechargeOscillator(PBModel):
 
     def __init__(
         self,
-        forcing=None,
         var_name="enso_recharge_oscillator",
         mu=0.7,
         en=0.0,
@@ -101,7 +139,6 @@ class ENSORechargeOscillator(PBModel):
             diagnostic_variables = []
 
         super().__init__(
-            forcing,
             var_name,
             state_variables=state_variables,
             diagnostic_variables=diagnostic_variables,
@@ -137,11 +174,12 @@ class ENSORechargeOscillator(PBModel):
 
     def _sst_forcing(self, t, state):
         Af = float(self.get_param_value("Af", t, state))
+        if Af == 0.0:
+            return 0.0
         Pf = float(self.get_param_value("Pf", t, state))
         if Pf == 0.0:
-            raise ValueError("Pf must be non-zero.")
-        seasonal = Af * np.sin(2.0 * np.pi * t / Pf)
-        return float(self.resolve_forcing(t, default=seasonal))
+            raise ValueError("Pf must be non-zero when Af != 0.")
+        return float(Af * np.sin(2.0 * np.pi * t / Pf))
 
     def recharge_components(self, t, state):
         T, h = [float(v) for v in np.asarray(state, dtype=float).reshape(-1)]

--- a/paleobeasts/signal_models/g24.py
+++ b/paleobeasts/signal_models/g24.py
@@ -64,8 +64,8 @@ class Model3(PBModel):
     from paleobeasts.signal_models.g24 import Model3, calc_f
     import matplotlib.pyplot as plt
 
-    orbital_forcing = pb.core.Forcing(calc_f)
-    model = Model3(forcing=orbital_forcing)
+    model = Model3()
+    model.register_forcing('insolation', pb.core.Forcing(calc_f))
 
     output = model.integrate(
         t_span=(-2000, 0), y0=[0.0, 1], method='RK45',
@@ -78,10 +78,11 @@ class Model3(PBModel):
     ```
     """
 
-    def __init__(self, forcing, var_name='ice volume', f1=-16, f2=16, t1=30, t2=10, vc=1.4,
+    def __init__(self, var_name='ice volume', f1=-16, f2=16, t1=30, t2=10, vc=1.4,
+                 insolation=0.0,
                  state_variables=['v', 'k'], non_integrated_state_vars=['k'], diagnostic_variables=['insolation'], *args,
                  **kwargs):
-        super().__init__(forcing, var_name, state_variables=state_variables,
+        super().__init__(var_name, state_variables=state_variables,
                          non_integrated_state_vars=non_integrated_state_vars,
                          diagnostic_variables=diagnostic_variables, *args, **kwargs)
         self.f1 = f1
@@ -89,6 +90,7 @@ class Model3(PBModel):
         self.t1 = t1
         self.t2 = t2
         self.vc = vc
+        self.insolation = insolation
         self.dfdt = calc_df
         self.param_values = {
             'f1': f1,
@@ -97,6 +99,7 @@ class Model3(PBModel):
             't2': t2,
             'vc': vc,
             'dfdt': self.dfdt,
+            'insolation': insolation,
         }
         self.params = ()
 
@@ -119,7 +122,7 @@ class Model3(PBModel):
         t2 = self.get_param_value('t2', t, x)
 
         k = int(self.state_variables['k'][-1])
-        f = self.forcing.get_forcing(self.time_util(t))
+        f = self.get_param_value('insolation', t, x)
         dfdt = self.calc_dfdt(self.time_util(t), x)
 
         vc = self.get_param_value('vc', t, x)

--- a/paleobeasts/signal_models/g24.py
+++ b/paleobeasts/signal_models/g24.py
@@ -20,8 +20,6 @@ class Model3(PBModel):
 
     Parameters
     ----------
-    forcing : pb.core.Forcing
-        Orbital insolation forcing ``f(t)`` (W m\ :sup:`-2`).  Required.
     var_name : str
         Label for the model output.  Default ``'ice volume'``.
     f1 : float or callable or pb.core.Forcing
@@ -43,6 +41,11 @@ class Model3(PBModel):
     State variables are ``v`` (ice volume, normalised) and ``k`` (regime
     index, non-integrated).  The diagnostic variable ``insolation`` records
     ``f(t)`` at each output step.
+
+    The ``insolation`` parameter (default 0.0) provides the orbital forcing
+    value used by the model.  Register a time-varying orbital signal via::
+
+        model.register_forcing('insolation', pb.core.Forcing(calc_f))
 
     The internal derivative of forcing ``dfdt`` is computed via
     :func:`calc_df` by default; supply a custom callable or

--- a/paleobeasts/signal_models/lorenz.py
+++ b/paleobeasts/signal_models/lorenz.py
@@ -69,14 +69,14 @@ class Lorenz96(PBModel):
     from paleobeasts.signal_models.lorenz import Lorenz96
 
     # Single-scale system
-    model = Lorenz96(forcing=None, n=40, F=8.0)
+    model = Lorenz96(n=40, F=8.0)
     y0 = np.random.randn(40) + 8.0
     output = model.integrate(t_span=(0, 10), y0=y0, method='rk4', dt=0.01)
     ts = output.to_pyleo(var_names=['x0'])
 
     # Two-scale system
     K, J = 36, 10
-    model2 = Lorenz96(forcing=None, n=K, J=J, F=10.0)
+    model2 = Lorenz96(n=K, J=J, F=10.0)
     y0_2 = np.concatenate([np.random.randn(K) + 10.0,
                             np.random.randn(K * J) * 0.01])
     output2 = model2.integrate(t_span=(0, 10), y0=y0_2,
@@ -89,7 +89,7 @@ class Lorenz96(PBModel):
     ```
     """
 
-    def __init__(self, forcing=None, var_name='lorenz96', n=40, J=0,
+    def __init__(self, var_name='lorenz96', n=40, J=0,
                  F=8.0, h=1.0, b=10.0, c=10.0, exact_rhs=False,
                  state_variables=None, diagnostic_variables=None,
                  *args, **kwargs):
@@ -100,7 +100,7 @@ class Lorenz96(PBModel):
         if diagnostic_variables is None:
             diagnostic_variables = []
 
-        super().__init__(forcing, var_name, state_variables=state_variables,
+        super().__init__(var_name, state_variables=state_variables,
                          diagnostic_variables=diagnostic_variables,
                          *args, **kwargs)
 
@@ -115,7 +115,7 @@ class Lorenz96(PBModel):
         self.params = ()
 
     def _forcing_value(self, t, x):
-        return self.resolve_forcing(t, default=self.get_param_value('F', t, x))
+        return self.get_param_value('F', t, x)
 
     def dydt(self, t, x):
         x = np.asarray(x, dtype=float)
@@ -224,7 +224,7 @@ class Lorenz63(PBModel):
     import paleobeasts as pb
     from paleobeasts.signal_models.lorenz import Lorenz63
 
-    model = Lorenz63(forcing=pb.core.Forcing(lambda t: 0.0))
+    model = Lorenz63()
     output = model.integrate(
         t_span=(0, 100), y0=[-8.0, 8.0, 27.0], method='RK45'
     )
@@ -237,14 +237,14 @@ class Lorenz63(PBModel):
     ```
     """
 
-    def __init__(self, forcing=None, var_name='lorenz63', sigma=10.0, rho=28.0, beta=8 / 3,
+    def __init__(self, var_name='lorenz63', sigma=10.0, rho=28.0, beta=8 / 3,
                  state_variables=None, diagnostic_variables=None, *args, **kwargs):
         if state_variables is None:
             state_variables = ['x', 'y', 'z']
         if diagnostic_variables is None:
             diagnostic_variables = []
 
-        super().__init__(forcing, var_name, state_variables=state_variables,
+        super().__init__(var_name, state_variables=state_variables,
                          diagnostic_variables=diagnostic_variables, *args, **kwargs)
 
         self.sigma = sigma
@@ -257,28 +257,15 @@ class Lorenz63(PBModel):
         }
         self.params = ()
 
-    def _forcing_vector(self, t):
-        f_val = self.resolve_forcing(t)
-
-        if np.isscalar(f_val):
-            return np.array([f_val, 0.0, 0.0])
-
-        f_arr = np.asarray(f_val, dtype=float)
-        if f_arr.size != 3:
-            raise ValueError("Forcing must be a scalar or an array-like with 3 entries.")
-
-        return f_arr.reshape(3,)
-
     def dydt(self, t, x):
         x_val, y_val, z_val = x[0], x[1], x[2]
         sigma = self.get_param_value('sigma', t, x)
         rho = self.get_param_value('rho', t, x)
         beta = self.get_param_value('beta', t, x)
-        f_vec = self._forcing_vector(t)
 
-        dxdt = sigma * (y_val - x_val) + f_vec[0]
-        dydt = x_val * (rho - z_val) - y_val + f_vec[1]
-        dzdt = x_val * y_val - beta * z_val + f_vec[2]
+        dxdt = sigma * (y_val - x_val)
+        dydt = x_val * (rho - z_val) - y_val
+        dzdt = x_val * y_val - beta * z_val
 
         new_row = np.array([(x_val, y_val, z_val)], dtype=self.dtypes)
         self.state_variables = np.concatenate([self.state_variables, new_row], axis=0)

--- a/paleobeasts/signal_models/lorenz.py
+++ b/paleobeasts/signal_models/lorenz.py
@@ -19,9 +19,6 @@ class Lorenz96(PBModel):
 
     Parameters
     ----------
-    forcing : pb.core.Forcing or None
-        Optional forcing object providing F(t).  If ``None``, the constant
-        ``F`` parameter is used as the slow-scale forcing.
     var_name : str
         Label for the model output.  Default ``'lorenz96'``.
     n : int
@@ -30,7 +27,8 @@ class Lorenz96(PBModel):
         Fast variables per slow variable.  ``J=0`` (default) gives the
         single-scale system; ``J>0`` activates the two-scale system.
     F : float or callable or pb.core.Forcing
-        Slow-scale forcing amplitude.  Default 8.0.
+        Slow-scale forcing amplitude.  Default 8.0.  Pass a time-varying
+        signal via ``model.register_forcing('F', forcing_obj)``.
     h : float
         Coupling coefficient between X and Y layers (two-scale only).
         Default 1.0.
@@ -190,11 +188,6 @@ class Lorenz63(PBModel):
 
     Parameters
     ----------
-    forcing : pb.core.Forcing or None
-        External forcing, which must be provided explicitly but may be
-        ``None``. If the forcing value ``f(t)`` is scalar it is added to
-        ``dx/dt``; if it is array-like with 3 entries it is added to
-        ``(dx/dt, dy/dt, dz/dt)``.
     var_name : str
         Label for the model output.  Default ``'lorenz63'``.
     sigma : float or callable or pb.core.Forcing

--- a/paleobeasts/signal_models/pendulum.py
+++ b/paleobeasts/signal_models/pendulum.py
@@ -69,7 +69,7 @@ class SimplePendulum(PBModel):
     import matplotlib.pyplot as plt
     from paleobeasts.signal_models.pendulum import SimplePendulum
 
-    model = SimplePendulum(forcing=None, L=1.0, g=9.81, damping=0.1)
+    model = SimplePendulum(L=1.0, g=9.81, damping=0.1)
     output = model.integrate(t_span=(0, 20), y0=[1.5, 0.0], method='RK45')
     ts = output.to_pyleo(var_names=['theta'])
     ts.plot()
@@ -80,7 +80,6 @@ class SimplePendulum(PBModel):
 
     def __init__(
         self,
-        forcing=None,
         var_name="simple_pendulum",
         L=1.0,
         g=9.81,
@@ -96,7 +95,6 @@ class SimplePendulum(PBModel):
             diagnostic_variables = ["energy", "omega_0"]
 
         super().__init__(
-            forcing,
             var_name,
             state_variables=state_variables,
             diagnostic_variables=diagnostic_variables,
@@ -127,7 +125,7 @@ class SimplePendulum(PBModel):
 
         omega0_sq = g / L
         dtheta = omega
-        domega = -lam * omega - omega0_sq * np.sin(theta) + self.resolve_forcing(t)
+        domega = -lam * omega - omega0_sq * np.sin(theta)
         return [dtheta, domega]
 
     def populate_diagnostics_from_history(self, time, history):
@@ -207,7 +205,7 @@ class DrivenPendulum(PBModel):
     import matplotlib.pyplot as plt
     from paleobeasts.signal_models.pendulum import DrivenPendulum
 
-    model = DrivenPendulum(forcing=None, q=0.5, A=1.2, Omega=2.0/3.0)
+    model = DrivenPendulum(q=0.5, A=1.2, Omega=2.0/3.0)
     output = model.integrate(
         t_span=(0, 500), y0=[0.0, 0.0], method='RK45',
         kwargs={'rtol': 1e-9, 'atol': 1e-11},
@@ -224,7 +222,6 @@ class DrivenPendulum(PBModel):
 
     def __init__(
         self,
-        forcing=None,
         var_name="driven_pendulum",
         q=0.5,
         A=1.2,
@@ -240,7 +237,6 @@ class DrivenPendulum(PBModel):
             diagnostic_variables = ["energy", "drive"]
 
         super().__init__(
-            forcing,
             var_name,
             state_variables=state_variables,
             diagnostic_variables=diagnostic_variables,
@@ -260,7 +256,7 @@ class DrivenPendulum(PBModel):
     def _drive(self, t):
         A = float(self.param_values["A"])
         Omega = float(self.param_values["Omega"])
-        return float(self.resolve_forcing(t, default=A * np.cos(Omega * t)))
+        return float(A * np.cos(Omega * t))
 
     def dydt(self, t, x):
         state = np.asarray(x, dtype=float).reshape(-1)
@@ -346,7 +342,7 @@ class DoublePendulum(PBModel):
     import numpy as np
     from paleobeasts.signal_models.pendulum import DoublePendulum
 
-    model = DoublePendulum(forcing=None, m1=1.0, m2=1.0, L1=1.0, L2=1.0)
+    model = DoublePendulum(m1=1.0, m2=1.0, L1=1.0, L2=1.0)
     output = model.integrate(
         t_span=(0, 60), y0=[np.pi/2, 0.0, np.pi/4, 0.0], method='RK45',
         kwargs={'rtol': 1e-10, 'atol': 1e-12},
@@ -360,7 +356,6 @@ class DoublePendulum(PBModel):
 
     def __init__(
         self,
-        forcing=None,
         var_name="double_pendulum",
         m1=1.0,
         m2=1.0,
@@ -380,7 +375,6 @@ class DoublePendulum(PBModel):
             diagnostic_variables = ["energy", "x1", "y1", "x2", "y2"]
 
         super().__init__(
-            forcing,
             var_name,
             state_variables=state_variables,
             diagnostic_variables=diagnostic_variables,
@@ -425,7 +419,7 @@ class DoublePendulum(PBModel):
             -g * (2.0 * m1 + m2) * np.sin(theta1)
             - m2 * g * np.sin(theta1 - 2.0 * theta2)
             - 2.0 * sin_d * m2 * (omega2 ** 2 * L2 + omega1 ** 2 * L1 * cos_d)
-        ) / denom - d1 * omega1 + self.resolve_forcing(t)
+        ) / denom - d1 * omega1
 
         domega2 = (
             2.0 * sin_d * (

--- a/paleobeasts/signal_models/pendulum.py
+++ b/paleobeasts/signal_models/pendulum.py
@@ -46,10 +46,6 @@ class SimplePendulum(PBModel):
 
     Parameters
     ----------
-    forcing:
-        Optional external torque applied additively to ``dω/dt``.  A scalar
-        ``Forcing`` value is added directly; if ``None``, the unforced
-        dynamics are used.
     var_name:
         Human-readable label.
     L:
@@ -62,6 +58,12 @@ class SimplePendulum(PBModel):
         Names for [angle, angular velocity].
     diagnostic_variables:
         Names for post-integration diagnostics.
+
+    Notes
+    -----
+    State variables are ``theta`` (angle, rad) and ``omega`` (angular velocity,
+    rad/s) in that order.  Diagnostic variables ``energy`` and ``omega_0`` are
+    computed after integration.
 
     Examples
     --------
@@ -181,19 +183,14 @@ class DrivenPendulum(PBModel):
 
     Parameters
     ----------
-    forcing:
-        Optional external drive.  If provided, ``forcing.get_forcing(t)``
-        replaces the built-in cosine term entirely, allowing arbitrary drive
-        waveforms.  When ``None``, the cosine drive ``A cos(Ω t)`` is used.
     var_name:
         Human-readable label.
     q:
         Damping coefficient (dimensionless).
     A:
-        Driving amplitude (dimensionless).  Ignored when ``forcing`` is set.
+        Driving amplitude (dimensionless).
     Omega:
-        Driving angular frequency (dimensionless rad/time).  Ignored when
-        ``forcing`` is set.
+        Driving angular frequency (dimensionless rad/time).
     state_variables:
         Names for [angle, angular velocity].
     diagnostic_variables:
@@ -306,10 +303,6 @@ class DoublePendulum(PBModel):
 
     Parameters
     ----------
-    forcing:
-        Optional external torque applied additively to ``dω₁/dt`` (the first
-        bob).  A scalar ``Forcing`` value is added directly; if ``None``, the
-        unforced dynamics are used.
     var_name:
         Human-readable label.
     m1, m2:
@@ -324,16 +317,15 @@ class DoublePendulum(PBModel):
 
     Notes
     -----
+    State variables are ``theta1``, ``omega1``, ``theta2``, ``omega2`` in
+    that order.  Diagnostic variables ``energy``, ``x1``, ``y1``, ``x2``,
+    ``y2`` are computed after integration.
+
     The double pendulum is chaotic.  RK45 with default tolerances can show
     significant energy drift for long or large-amplitude runs.  Use tight
     tolerances for accurate energy tracking::
 
         model.integrate(..., kwargs={'rtol': 1e-10, 'atol': 1e-12})
-
-    state_variables:
-        Names for [θ₁, ω₁, θ₂, ω₂].
-    diagnostic_variables:
-        Names for post-integration diagnostics.
 
     Examples
     --------

--- a/paleobeasts/signal_models/roessler.py
+++ b/paleobeasts/signal_models/roessler.py
@@ -14,10 +14,6 @@ class Roessler(PBModel):
 
     Parameters
     ----------
-    forcing : pb.core.Forcing or None
-        External forcing applied additively to the equations.  If the value
-        at time t is scalar it is added to dx/dt only; if it is a 3-element
-        array it is added component-wise.  Default ``None``.
     var_name : str
         Label for the model output.  Default ``'roessler'``.
     a : float or callable or pb.core.Forcing

--- a/paleobeasts/signal_models/roessler.py
+++ b/paleobeasts/signal_models/roessler.py
@@ -45,7 +45,7 @@ class Roessler(PBModel):
     import matplotlib.pyplot as plt
     from paleobeasts.signal_models.roessler import Roessler
 
-    model = Roessler(forcing=None)
+    model = Roessler()
     output = model.integrate(
         t_span=(0, 200), y0=[0.1, 0.0, 0.0], method='RK45'
     )
@@ -60,7 +60,6 @@ class Roessler(PBModel):
 
     def __init__(
         self,
-        forcing=None,
         var_name='roessler',
         a=0.2,
         b=0.2,
@@ -76,7 +75,6 @@ class Roessler(PBModel):
             diagnostic_variables = []
 
         super().__init__(
-            forcing,
             var_name,
             state_variables=state_variables,
             diagnostic_variables=diagnostic_variables,
@@ -94,25 +92,15 @@ class Roessler(PBModel):
         }
         self.params = ()
 
-    def _forcing_vector(self, t):
-        f_val = self.resolve_forcing(t)
-        if np.isscalar(f_val):
-            return np.array([f_val, 0.0, 0.0])
-        f_arr = np.asarray(f_val, dtype=float)
-        if f_arr.size != 3:
-            raise ValueError("Forcing must be a scalar or an array-like with 3 entries.")
-        return f_arr.reshape(3,)
-
     def dydt(self, t, state):
         x_val, y_val, z_val = state[0], state[1], state[2]
         a = self.get_param_value('a', t, state)
         b = self.get_param_value('b', t, state)
         c = self.get_param_value('c', t, state)
 
-        f_vec = self._forcing_vector(t)
-        dxdt = -y_val - z_val + f_vec[0]
-        dydt = x_val + a * y_val + f_vec[1]
-        dzdt = b + z_val * (x_val - c) + f_vec[2]
+        dxdt = -y_val - z_val
+        dydt = x_val + a * y_val
+        dzdt = b + z_val * (x_val - c)
 
         new_row = np.array([(x_val, y_val, z_val)], dtype=self.dtypes)
         self.state_variables = np.concatenate([self.state_variables, new_row], axis=0)

--- a/paleobeasts/signal_models/stocker2003_bipolar_seesaw.py
+++ b/paleobeasts/signal_models/stocker2003_bipolar_seesaw.py
@@ -59,11 +59,10 @@ class Stocker2003BipolarSeesaw(PBModel):
         Stocker2003BipolarSeesaw,
     )
 
-    # Square-wave northern forcing
-    Tn = pb.core.Forcing(lambda t: 1.0 if (t % 2000) < 1000 else -1.0)
     import matplotlib.pyplot as plt
 
-    model = Stocker2003BipolarSeesaw(forcing=Tn, tau=500.0, beta=-1.0)
+    model = Stocker2003BipolarSeesaw(tau=500.0, beta=-1.0)
+    model.register_forcing('Tn', pb.core.Forcing(lambda t: 1.0 if (t % 2000) < 1000 else -1.0))
     output = model.integrate(
         t_span=(0, 8000), y0=[0.0], method='RK45'
     )
@@ -76,7 +75,6 @@ class Stocker2003BipolarSeesaw(PBModel):
 
     def __init__(
         self,
-        forcing=None,
         var_name="stocker2003_bipolar_seesaw",
         tau=1000.0,
         beta=-1.0,
@@ -92,7 +90,6 @@ class Stocker2003BipolarSeesaw(PBModel):
             diagnostic_variables = ["Tn"]
 
         super().__init__(
-            forcing,
             var_name,
             state_variables=state_variables,
             diagnostic_variables=diagnostic_variables,
@@ -118,7 +115,7 @@ class Stocker2003BipolarSeesaw(PBModel):
         if tau <= 0:
             raise ValueError("tau must be > 0.")
         beta = float(self.get_param_value("beta", t, x))
-        Tn_t = float(self.resolve_forcing(t, default=self.get_param_value("Tn", t, x)))
+        Tn_t = float(self.get_param_value("Tn", t, x))
         dTsdt = (beta * Tn_t - Ts) / tau
         return [dTsdt]
 
@@ -127,7 +124,7 @@ class Stocker2003BipolarSeesaw(PBModel):
         history = np.asarray(history, dtype=float)
         Tn_vals = []
         for t, row in zip(time, history):
-            Tn_vals.append(float(self.resolve_forcing(t, default=self.get_param_value("Tn", t, row))))
+            Tn_vals.append(float(self.get_param_value("Tn", t, row)))
         Tn_vals = np.asarray(Tn_vals, dtype=float)
         self.diagnostic_variables = {"Tn": Tn_vals}
 
@@ -205,8 +202,8 @@ class Stocker2003ExtendedSeaIceSeesaw(PBModel):
     import matplotlib.pyplot as plt
 
 
-    T_N = pb.core.Forcing(lambda t: 1.0 if (t % 2000) < 1000 else 0.0)
-    model = Stocker2003ExtendedSeaIceSeesaw(forcing=T_N)
+    model = Stocker2003ExtendedSeaIceSeesaw()
+    model.register_forcing('T_N', pb.core.Forcing(lambda t: 1.0 if (t % 2000) < 1000 else 0.0))
     output = model.integrate(
         t_span=(0, 10000), y0=[0.0, 0.0, 0.3, 0.0], method='RK45'
     )
@@ -219,7 +216,6 @@ class Stocker2003ExtendedSeaIceSeesaw(PBModel):
 
     def __init__(
         self,
-        forcing=None,
         var_name="stocker2003_extended_seaice_seesaw",
         tau_R=300.0,
         tau_S=1200.0,
@@ -250,7 +246,6 @@ class Stocker2003ExtendedSeaIceSeesaw(PBModel):
             diagnostic_variables = ["T_N"]
 
         super().__init__(
-            forcing,
             var_name,
             state_variables=state_variables,
             diagnostic_variables=diagnostic_variables,
@@ -302,7 +297,7 @@ class Stocker2003ExtendedSeaIceSeesaw(PBModel):
     uses_post_history = True
 
     def resolve_north(self, t, state):
-        return float(self.resolve_forcing(t, default=self.get_param_value("T_N", t, state)))
+        return float(self.get_param_value("T_N", t, state))
 
     def dydt(self, t, x):
         state = np.asarray(x, dtype=float).reshape(-1)

--- a/paleobeasts/signal_models/stocker2003_bipolar_seesaw.py
+++ b/paleobeasts/signal_models/stocker2003_bipolar_seesaw.py
@@ -24,10 +24,6 @@ class Stocker2003BipolarSeesaw(PBModel):
 
     Parameters
     ----------
-    forcing : pb.core.Forcing or None
-        Optional time-varying northern temperature anomaly ``Tn(t)``
-        (model units).  If ``None``, the constant ``Tn`` parameter is used.
-        Default ``None``.
     var_name : str
         Label for the model output.  Default ``'stocker2003_bipolar_seesaw'``.
     tau : float or callable or pb.core.Forcing
@@ -36,8 +32,8 @@ class Stocker2003BipolarSeesaw(PBModel):
         Amplitude ratio relating southern to northern anomaly.  Default -1.0
         (antiphase seesaw).
     Tn : float or callable or pb.core.Forcing
-        Constant northern temperature anomaly used when no forcing is
-        provided.  Default 0.0.
+        Northern temperature anomaly.  Default 0.0.  Register a
+        time-varying signal via ``model.register_forcing('Tn', forcing_obj)``.
 
     Notes
     -----
@@ -147,9 +143,6 @@ class Stocker2003ExtendedSeaIceSeesaw(PBModel):
 
     Parameters
     ----------
-    forcing : pb.core.Forcing or None
-        Optional time-varying northern temperature anomaly ``T_N(t)``.  If
-        ``None``, the constant ``T_N`` parameter is used.  Default ``None``.
     var_name : str
         Label for the model output.  Default
         ``'stocker2003_extended_seaice_seesaw'``.
@@ -181,8 +174,8 @@ class Stocker2003ExtendedSeaIceSeesaw(PBModel):
     T_c : float
         Critical temperature for the sea-ice feedback.  Default 0.0.
     T_N : float
-        Constant northern temperature when no forcing is provided.
-        Default 0.0.
+        Northern temperature anomaly.  Default 0.0.  Register a
+        time-varying signal via ``model.register_forcing('T_N', forcing_obj)``.
     epsilon_R, epsilon_S, epsilon_A, epsilon_ANT : float
         Constant additive noise / bias terms.  All default to 0.0.
 

--- a/paleobeasts/signal_models/stommel.py
+++ b/paleobeasts/signal_models/stommel.py
@@ -15,16 +15,11 @@ class Stommel(PBModel):
 
     and the prognostic equations are:
 
-        dT/dt = -lambda_T * (T - T_star) - |q|*T + f_T(t)
-        dS/dt =  E - lambda_S * (S - S_star) - |q|*S + f_S(t)
+        dT/dt = -lambda_T * (T - T_star) - |q|*T
+        dS/dt =  E - lambda_S * (S - S_star) - |q|*S
 
     Parameters
     ----------
-    forcing : pb.core.Forcing or None
-        Optional external forcing.  If the forcing value is scalar it is
-        applied as a freshwater perturbation added to ``dS/dt``.  If
-        array-like with 2 entries, it is added to ``(dT/dt, dS/dt)``
-        respectively.  Default ``None``.
     var_name : str
         Label for the model output.  Default ``'stommel'``.
     alpha : float or callable or pb.core.Forcing
@@ -54,6 +49,17 @@ class Stommel(PBModel):
     ----------
     Stommel, H. (1961). Thermohaline convection with two stable regimes of
     flow. Tellus, 13(2), 224–230.
+
+    Notes
+    -----
+    State variables are ``T`` and ``S`` (in that order).  Diagnostic
+    variable is ``q`` (overturning strength), computed after integration.
+
+    To drive the salinity equation with an external freshwater forcing::
+
+        model = Stommel(E=0.0)
+        model.register_forcing('S', pb.core.Forcing(lambda t: 0.1),
+                               attachment_style='additive', timing='pre')
 
     Examples
     --------

--- a/paleobeasts/signal_models/stommel.py
+++ b/paleobeasts/signal_models/stommel.py
@@ -62,7 +62,7 @@ class Stommel(PBModel):
     from paleobeasts.signal_models.stommel import Stommel
     import matplotlib.pyplot as plt
 
-    model = Stommel(forcing=None, E=0.3, T_star=1.0, S_star=0.0)
+    model = Stommel(E=0.3, T_star=1.0, S_star=0.0)
     output = model.integrate(
         t_span=(0, 50), y0=[1.0, 0.0], method='RK45'
     )
@@ -73,7 +73,7 @@ class Stommel(PBModel):
     ```
     """
 
-    def __init__(self, forcing=None, var_name='stommel', alpha=1.0, beta=1.0, k=1.0, E=0.0,
+    def __init__(self, var_name='stommel', alpha=1.0, beta=1.0, k=1.0, E=0.0,
                  lambda_T=1.0, lambda_S=1.0, T_star=1.0, S_star=0.0, state_variables=None,
                  diagnostic_variables=None, *args, **kwargs):
         if state_variables is None:
@@ -81,7 +81,7 @@ class Stommel(PBModel):
         if diagnostic_variables is None:
             diagnostic_variables = ['q']
 
-        super().__init__(forcing, var_name, state_variables=state_variables,
+        super().__init__(var_name, state_variables=state_variables,
                          diagnostic_variables=diagnostic_variables, *args, **kwargs)
 
         self.alpha = alpha
@@ -104,16 +104,6 @@ class Stommel(PBModel):
         }
         self.params = ()
 
-    def _forcing_vector(self, t):
-        f_val = self.resolve_forcing(t)
-        if np.isscalar(f_val):
-            return np.array([0.0, float(f_val)])
-
-        f_arr = np.asarray(f_val, dtype=float)
-        if f_arr.size != 2:
-            raise ValueError("Forcing must be a scalar or an array-like with 2 entries.")
-        return f_arr.reshape(2,)
-
     def overturning(self, t, x):
         T, S = x[0], x[1]
         alpha = self.get_param_value('alpha', t, x)
@@ -134,10 +124,8 @@ class Stommel(PBModel):
         lambda_S = self.get_param_value('lambda_S', t, x)
         T_star = self.get_param_value('T_star', t, x)
         S_star = self.get_param_value('S_star', t, x)
-        f_vec = self._forcing_vector(t)
-
-        dTdt = -lambda_T * (T - T_star) - adv * T + f_vec[0]
-        dSdt = E - lambda_S * (S - S_star) - adv * S + f_vec[1]
+        dTdt = -lambda_T * (T - T_star) - adv * T
+        dSdt = E - lambda_S * (S - S_star) - adv * S
 
         return [dTdt, dSdt]
 

--- a/paleobeasts/signal_models/two_box_carbon.py
+++ b/paleobeasts/signal_models/two_box_carbon.py
@@ -52,7 +52,7 @@ class TwoBoxCarbon(PBModel):
     from paleobeasts.signal_models.two_box_carbon import TwoBoxCarbon
     import matplotlib.pyplot as plt
 
-    model = TwoBoxCarbon(forcing=None, k=0.1, V_atm=1.0, V_surf=50.0)
+    model = TwoBoxCarbon(k=0.1, V_atm=1.0, V_surf=50.0)
     output = model.integrate(
         t_span=(0, 200), y0=[800.0, 38000.0], method='RK45'
     )
@@ -65,7 +65,6 @@ class TwoBoxCarbon(PBModel):
 
     def __init__(
         self,
-        forcing=None,
         var_name="two_box_carbon",
         k=0.2,
         R=0.0,
@@ -83,7 +82,6 @@ class TwoBoxCarbon(PBModel):
             diagnostic_variables = ["net_flux"]
 
         super().__init__(
-            forcing,
             var_name,
             state_variables=state_variables,
             diagnostic_variables=diagnostic_variables,
@@ -109,8 +107,6 @@ class TwoBoxCarbon(PBModel):
         return True
 
     def source_flux(self, t, state):
-        if self.forcing is not None:
-            return float(self.forcing.get_forcing(self.time_util(t)))
         return float(self.get_param_value("R", t, state))
 
     def tendencies(self, t, state):

--- a/paleobeasts/signal_models/two_box_carbon.py
+++ b/paleobeasts/signal_models/two_box_carbon.py
@@ -18,10 +18,6 @@ class TwoBoxCarbon(PBModel):
 
     Parameters
     ----------
-    forcing : pb.core.Forcing or None
-        Optional prescribed carbon source flux ``R(t)`` (same units as
-        ``R``).  If provided it overrides the constant ``R`` parameter.
-        Default ``None``.
     var_name : str
         Label for the model output.  Default ``'two_box_carbon'``.
     k : float or callable or pb.core.Forcing
@@ -29,7 +25,8 @@ class TwoBoxCarbon(PBModel):
         Default 0.2.
     R : float or callable or pb.core.Forcing
         Constant carbon source flux into the atmosphere (mass per time).
-        Default 0.0.
+        Default 0.0.  Register a time-varying source via
+        ``model.register_forcing('R', forcing_obj)``.
     l_s : float or callable or pb.core.Forcing
         First-order atmospheric loss coefficient.  Default 0.0.
     V_atm : float or callable or pb.core.Forcing

--- a/paleobeasts/tests/test_core_forcing.py
+++ b/paleobeasts/tests/test_core_forcing.py
@@ -166,6 +166,7 @@ class TestForcingModelIntegration:
             ],
             label="stommel_sequence",
         )
-        model = stommel.Stommel(forcing=forcing, E=0.0)
+        model = stommel.Stommel(E=0.0)
+        model.register_forcing('S', forcing, attachment_style='additive', timing='pre')
         model.integrate(t_span=(0, 0.05), y0=[1.0, 0.1], method="euler", dt=0.01)
         assert np.isfinite(model.state_variables["S"][-1])

--- a/paleobeasts/tests/test_core_forcing.py
+++ b/paleobeasts/tests/test_core_forcing.py
@@ -103,6 +103,60 @@ class TestForcingSequence:
             pb.Ramp(duration=1.0, y0=0.0, yf=1.0, shape="sigmoid")
 
 
+class TestForcingSpec:
+    def _make(self, **kwargs):
+        defaults = dict(
+            forcing_object=pb.Forcing(lambda t: 1.0),
+            attachment_style="replacement",
+            timing="pre",
+        )
+        defaults.update(kwargs)
+        from paleobeasts.core.forcing import ForcingSpec
+        return ForcingSpec(**defaults)
+
+    def test_valid_replacement_pre_t0(self):
+        spec = self._make(attachment_style="replacement", timing="pre")
+        assert spec.attachment_style == "replacement"
+        assert spec.timing == "pre"
+
+    def test_valid_additive_post_t1(self):
+        spec = self._make(attachment_style="additive", timing="post")
+        assert spec.timing == "post"
+
+    def test_invalid_attachment_style_raises_t2(self):
+        with pytest.raises(ValueError, match="attachment_style"):
+            self._make(attachment_style="multiply")
+
+    def test_invalid_timing_raises_t3(self):
+        with pytest.raises(ValueError, match="timing"):
+            self._make(timing="during")
+
+    def test_non_callable_forcing_object_raises_t4(self):
+        with pytest.raises(TypeError, match="forcing_object"):
+            self._make(forcing_object=42)
+
+    def test_evaluate_callable_t5(self):
+        from paleobeasts.core.forcing import ForcingSpec
+        spec = ForcingSpec(forcing_object=lambda t: t * 2.0, attachment_style="replacement", timing="pre")
+        assert np.isclose(spec.evaluate(3.0), 6.0)
+
+    def test_evaluate_forcing_object_t6(self):
+        from paleobeasts.core.forcing import ForcingSpec
+        spec = ForcingSpec(forcing_object=pb.Forcing(lambda t: t + 1.0), attachment_style="additive", timing="post")
+        assert np.isclose(spec.evaluate(4.0), 5.0)
+
+    def test_object_with_get_forcing_method_accepted_t7(self):
+        """Any object with get_forcing is valid, not just pb.Forcing."""
+        from paleobeasts.core.forcing import ForcingSpec
+
+        class CustomForcing:
+            def get_forcing(self, t):
+                return 99.0
+
+        spec = ForcingSpec(forcing_object=CustomForcing(), attachment_style="replacement", timing="pre")
+        assert np.isclose(spec.evaluate(0.0), 99.0)
+
+
 class TestForcingModelIntegration:
     def test_stommel_sequence_forcing_t0(self):
         forcing = pb.Forcing.from_sequence(

--- a/paleobeasts/tests/test_core_pbmodel_register_forcing.py
+++ b/paleobeasts/tests/test_core_pbmodel_register_forcing.py
@@ -1,0 +1,208 @@
+"""Tests for PBModel.register_forcing, get_forcings, and clear_forcings.
+
+Naming rules:
+1. class: Test{filename}{Class}{method} with appropriate camel case
+2. function: test_{method}_t{test_id}
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import paleobeasts as pb
+from paleobeasts.core.forcing import ForcingSpec
+from paleobeasts.signal_models import lorenz, stommel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _forcing():
+    """Minimal valid Forcing object for use in tests."""
+    return pb.Forcing(lambda t: 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Parameter namespace
+# ---------------------------------------------------------------------------
+
+class TestRegisterForcingParameter:
+    def test_parameter_defaults_replacement_pre_t0(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('sigma', _forcing())
+        specs = model.get_forcings('sigma')
+        assert len(specs) == 1
+        assert specs[0].attachment_style == 'replacement'
+        assert specs[0].timing == 'pre'
+
+    def test_parameter_explicit_replacement_t1(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('rho', _forcing(), attachment_style='replacement')
+        specs = model.get_forcings('rho')
+        assert specs[0].attachment_style == 'replacement'
+
+    def test_parameter_additive_raises_t2(self):
+        model = lorenz.Lorenz63(forcing=None)
+        with pytest.raises(ValueError, match="attachment_style='replacement'"):
+            model.register_forcing('sigma', _forcing(), attachment_style='additive')
+
+    def test_parameter_timing_pre_explicit_ok_t3(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('beta', _forcing(), timing='pre')
+        assert model.get_forcings('beta')[0].timing == 'pre'
+
+    def test_parameter_timing_post_raises_t4(self):
+        model = lorenz.Lorenz63(forcing=None)
+        with pytest.raises(ValueError, match="pre-step"):
+            model.register_forcing('sigma', _forcing(), timing='post')
+
+    def test_parameter_double_replacement_raises_t5(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('rho', _forcing())
+        with pytest.raises(ValueError, match="replacement forcing is already registered"):
+            model.register_forcing('rho', _forcing())
+
+
+# ---------------------------------------------------------------------------
+# State variable namespace
+# ---------------------------------------------------------------------------
+
+class TestRegisterForcingState:
+    def test_state_no_attachment_style_raises_t0(self):
+        model = lorenz.Lorenz63(forcing=None)
+        with pytest.raises(ValueError, match="attachment_style is required"):
+            model.register_forcing('x', _forcing())
+
+    def test_state_replacement_defaults_post_t1(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('x', _forcing(), attachment_style='replacement')
+        specs = model.get_forcings('x')
+        assert specs[0].timing == 'post'
+
+    def test_state_replacement_pre_warns_and_uses_post_t2(self):
+        model = lorenz.Lorenz63(forcing=None)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            model.register_forcing('x', _forcing(), attachment_style='replacement', timing='pre')
+        assert any(issubclass(w.category, UserWarning) for w in caught)
+        assert model.get_forcings('x')[0].timing == 'post'
+
+    def test_state_additive_pre_t3(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('y', _forcing(), attachment_style='additive', timing='pre')
+        spec = model.get_forcings('y')[0]
+        assert spec.attachment_style == 'additive'
+        assert spec.timing == 'pre'
+
+    def test_state_additive_post_t4(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('z', _forcing(), attachment_style='additive', timing='post')
+        assert model.get_forcings('z')[0].timing == 'post'
+
+    def test_state_additive_missing_timing_raises_t5(self):
+        model = lorenz.Lorenz63(forcing=None)
+        with pytest.raises(ValueError, match="timing is required"):
+            model.register_forcing('x', _forcing(), attachment_style='additive')
+
+    def test_state_double_replacement_raises_t6(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('x', _forcing(), attachment_style='replacement')
+        with pytest.raises(ValueError, match="replacement forcing is already registered"):
+            model.register_forcing('x', _forcing(), attachment_style='replacement')
+
+    def test_state_multiple_additive_allowed_t7(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('x', _forcing(), attachment_style='additive', timing='pre')
+        model.register_forcing('x', pb.Forcing(lambda t: 2.0), attachment_style='additive', timing='pre')
+        assert len(model.get_forcings('x')) == 2
+
+
+# ---------------------------------------------------------------------------
+# Unknown variable
+# ---------------------------------------------------------------------------
+
+class TestRegisterForcingUnknownVar:
+    def test_unknown_var_raises_t0(self):
+        model = lorenz.Lorenz63(forcing=None)
+        with pytest.raises(ValueError, match="not found"):
+            model.register_forcing('not_a_var', _forcing())
+
+    def test_error_message_lists_valid_names_t1(self):
+        model = lorenz.Lorenz63(forcing=None)
+        with pytest.raises(ValueError) as exc_info:
+            model.register_forcing('bogus', _forcing())
+        assert 'sigma' in str(exc_info.value) or 'rho' in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Registry inspection and clearing
+# ---------------------------------------------------------------------------
+
+class TestGetAndClearForcings:
+    def test_get_forcings_all_t0(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('sigma', _forcing())
+        model.register_forcing('x', _forcing(), attachment_style='additive', timing='pre')
+        registry = model.get_forcings()
+        assert 'sigma' in registry
+        assert 'x' in registry
+
+    def test_get_forcings_empty_var_returns_empty_list_t1(self):
+        model = lorenz.Lorenz63(forcing=None)
+        assert model.get_forcings('sigma') == []
+
+    def test_clear_specific_var_t2(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('sigma', _forcing())
+        model.register_forcing('rho', _forcing())
+        model.clear_forcings('sigma')
+        assert model.get_forcings('sigma') == []
+        assert len(model.get_forcings('rho')) == 1
+
+    def test_clear_all_t3(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('sigma', _forcing())
+        model.register_forcing('rho', _forcing())
+        model.clear_forcings()
+        assert model.get_forcings() == {}
+
+    def test_clear_nonexistent_var_is_silent_t4(self):
+        model = lorenz.Lorenz63(forcing=None)
+        model.clear_forcings('sigma')  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Copy behaviour
+# ---------------------------------------------------------------------------
+
+class TestRegisterForcingCopy:
+    def test_copy_carries_forcings_t0(self):
+        import copy
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('sigma', _forcing())
+        copied = copy.copy(model)
+        assert len(copied.get_forcings('sigma')) == 1
+
+    def test_copy_forcings_are_independent_t1(self):
+        """Appending to the copy's registry must not affect the original."""
+        import copy
+        model = lorenz.Lorenz63(forcing=None)
+        model.register_forcing('sigma', _forcing())
+        copied = copy.copy(model)
+        copied.register_forcing('rho', _forcing())
+        assert model.get_forcings('rho') == []
+
+
+# ---------------------------------------------------------------------------
+# ForcingSpec.evaluate is wired correctly through register_forcing
+# ---------------------------------------------------------------------------
+
+class TestForcingSpecEvaluate:
+    def test_evaluate_via_spec_t0(self):
+        model = lorenz.Lorenz63(forcing=None)
+        f = pb.Forcing(lambda t: t * 3.0)
+        model.register_forcing('sigma', f)
+        spec = model.get_forcings('sigma')[0]
+        assert np.isclose(spec.evaluate(2.0), 6.0)

--- a/paleobeasts/tests/test_core_pbmodel_register_forcing.py
+++ b/paleobeasts/tests/test_core_pbmodel_register_forcing.py
@@ -30,7 +30,7 @@ def _forcing():
 
 class TestRegisterForcingParameter:
     def test_parameter_defaults_replacement_pre_t0(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('sigma', _forcing())
         specs = model.get_forcings('sigma')
         assert len(specs) == 1
@@ -38,28 +38,28 @@ class TestRegisterForcingParameter:
         assert specs[0].timing == 'pre'
 
     def test_parameter_explicit_replacement_t1(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('rho', _forcing(), attachment_style='replacement')
         specs = model.get_forcings('rho')
         assert specs[0].attachment_style == 'replacement'
 
     def test_parameter_additive_raises_t2(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         with pytest.raises(ValueError, match="attachment_style='replacement'"):
             model.register_forcing('sigma', _forcing(), attachment_style='additive')
 
     def test_parameter_timing_pre_explicit_ok_t3(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('beta', _forcing(), timing='pre')
         assert model.get_forcings('beta')[0].timing == 'pre'
 
     def test_parameter_timing_post_raises_t4(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         with pytest.raises(ValueError, match="pre-step"):
             model.register_forcing('sigma', _forcing(), timing='post')
 
     def test_parameter_double_replacement_raises_t5(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('rho', _forcing())
         with pytest.raises(ValueError, match="replacement forcing is already registered"):
             model.register_forcing('rho', _forcing())
@@ -71,18 +71,18 @@ class TestRegisterForcingParameter:
 
 class TestRegisterForcingState:
     def test_state_no_attachment_style_raises_t0(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         with pytest.raises(ValueError, match="attachment_style is required"):
             model.register_forcing('x', _forcing())
 
     def test_state_replacement_defaults_post_t1(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('x', _forcing(), attachment_style='replacement')
         specs = model.get_forcings('x')
         assert specs[0].timing == 'post'
 
     def test_state_replacement_pre_warns_and_uses_post_t2(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter('always')
             model.register_forcing('x', _forcing(), attachment_style='replacement', timing='pre')
@@ -90,30 +90,30 @@ class TestRegisterForcingState:
         assert model.get_forcings('x')[0].timing == 'post'
 
     def test_state_additive_pre_t3(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('y', _forcing(), attachment_style='additive', timing='pre')
         spec = model.get_forcings('y')[0]
         assert spec.attachment_style == 'additive'
         assert spec.timing == 'pre'
 
     def test_state_additive_post_t4(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('z', _forcing(), attachment_style='additive', timing='post')
         assert model.get_forcings('z')[0].timing == 'post'
 
     def test_state_additive_missing_timing_raises_t5(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         with pytest.raises(ValueError, match="timing is required"):
             model.register_forcing('x', _forcing(), attachment_style='additive')
 
     def test_state_double_replacement_raises_t6(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('x', _forcing(), attachment_style='replacement')
         with pytest.raises(ValueError, match="replacement forcing is already registered"):
             model.register_forcing('x', _forcing(), attachment_style='replacement')
 
     def test_state_multiple_additive_allowed_t7(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('x', _forcing(), attachment_style='additive', timing='pre')
         model.register_forcing('x', pb.Forcing(lambda t: 2.0), attachment_style='additive', timing='pre')
         assert len(model.get_forcings('x')) == 2
@@ -125,12 +125,12 @@ class TestRegisterForcingState:
 
 class TestRegisterForcingUnknownVar:
     def test_unknown_var_raises_t0(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         with pytest.raises(ValueError, match="not found"):
             model.register_forcing('not_a_var', _forcing())
 
     def test_error_message_lists_valid_names_t1(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         with pytest.raises(ValueError) as exc_info:
             model.register_forcing('bogus', _forcing())
         assert 'sigma' in str(exc_info.value) or 'rho' in str(exc_info.value)
@@ -142,7 +142,7 @@ class TestRegisterForcingUnknownVar:
 
 class TestGetAndClearForcings:
     def test_get_forcings_all_t0(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('sigma', _forcing())
         model.register_forcing('x', _forcing(), attachment_style='additive', timing='pre')
         registry = model.get_forcings()
@@ -150,11 +150,11 @@ class TestGetAndClearForcings:
         assert 'x' in registry
 
     def test_get_forcings_empty_var_returns_empty_list_t1(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         assert model.get_forcings('sigma') == []
 
     def test_clear_specific_var_t2(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('sigma', _forcing())
         model.register_forcing('rho', _forcing())
         model.clear_forcings('sigma')
@@ -162,14 +162,14 @@ class TestGetAndClearForcings:
         assert len(model.get_forcings('rho')) == 1
 
     def test_clear_all_t3(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('sigma', _forcing())
         model.register_forcing('rho', _forcing())
         model.clear_forcings()
         assert model.get_forcings() == {}
 
     def test_clear_nonexistent_var_is_silent_t4(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.clear_forcings('sigma')  # should not raise
 
 
@@ -180,7 +180,7 @@ class TestGetAndClearForcings:
 class TestRegisterForcingCopy:
     def test_copy_carries_forcings_t0(self):
         import copy
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('sigma', _forcing())
         copied = copy.copy(model)
         assert len(copied.get_forcings('sigma')) == 1
@@ -188,7 +188,7 @@ class TestRegisterForcingCopy:
     def test_copy_forcings_are_independent_t1(self):
         """Appending to the copy's registry must not affect the original."""
         import copy
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         model.register_forcing('sigma', _forcing())
         copied = copy.copy(model)
         copied.register_forcing('rho', _forcing())
@@ -201,8 +201,122 @@ class TestRegisterForcingCopy:
 
 class TestForcingSpecEvaluate:
     def test_evaluate_via_spec_t0(self):
-        model = lorenz.Lorenz63(forcing=None)
+        model = lorenz.Lorenz63()
         f = pb.Forcing(lambda t: t * 3.0)
         model.register_forcing('sigma', f)
         spec = model.get_forcings('sigma')[0]
         assert np.isclose(spec.evaluate(2.0), 6.0)
+
+
+# ---------------------------------------------------------------------------
+# Integration behaviour — pre-step parameter replacement
+# ---------------------------------------------------------------------------
+
+class TestIntegrationPreStepParameter:
+    def test_parameter_replacement_affects_trajectory_t0(self):
+        """A constant parameter forcing should produce the same trajectory as
+        setting that parameter value directly."""
+        f_const = 12.0
+
+        # baseline: set sigma directly
+        m_base = lorenz.Lorenz63()
+        m_base.sigma = f_const
+        out_base = m_base.integrate(t_span=(0, 1), y0=[1, 1, 1], method='euler', dt=0.01)
+
+        # forced: register a constant forcing on sigma
+        m_forced = lorenz.Lorenz63()
+        m_forced.register_forcing('sigma', pb.Forcing(lambda t: f_const))
+        out_forced = m_forced.integrate(t_span=(0, 1), y0=[1, 1, 1], method='euler', dt=0.01)
+
+        np.testing.assert_allclose(
+            out_forced.state_variables['x'],
+            out_base.state_variables['x'],
+            rtol=1e-10,
+        )
+
+    def test_parameter_replacement_restores_after_step_t1(self):
+        """param_values must be restored to original after each dydt call."""
+        model = lorenz.Lorenz63()
+        original_sigma = model.sigma
+        model.register_forcing('sigma', pb.Forcing(lambda t: original_sigma * 2))
+        model.integrate(t_span=(0, 0.1), y0=[1, 1, 1], method='euler', dt=0.01)
+        assert model.param_values['sigma'] == original_sigma
+
+
+# ---------------------------------------------------------------------------
+# Integration behaviour — pre-step state additive
+# ---------------------------------------------------------------------------
+
+class TestIntegrationPreStepStateAdditive:
+    def test_additive_pre_shifts_trajectory_t0(self):
+        """Adding a positive constant to dx/dt should increase x relative to
+        the unforced trajectory."""
+        m_base = lorenz.Lorenz63()
+        out_base = m_base.integrate(t_span=(0, 2), y0=[1, 1, 1], method='euler', dt=0.01)
+
+        m_forced = lorenz.Lorenz63()
+        m_forced.register_forcing('x', pb.Forcing(lambda t: 1.0),
+                                  attachment_style='additive', timing='pre')
+        out_forced = m_forced.integrate(t_span=(0, 2), y0=[1, 1, 1], method='euler', dt=0.01)
+
+        # forced x trajectory should differ from baseline
+        assert not np.allclose(out_forced.state_variables['x'],
+                               out_base.state_variables['x'])
+
+    def test_zero_additive_pre_matches_baseline_t1(self):
+        """A zero additive forcing should leave the trajectory unchanged."""
+        m_base = lorenz.Lorenz63()
+        out_base = m_base.integrate(t_span=(0, 1), y0=[1, 1, 1], method='euler', dt=0.01)
+
+        m_forced = lorenz.Lorenz63()
+        m_forced.register_forcing('x', pb.Forcing(lambda t: 0.0),
+                                  attachment_style='additive', timing='pre')
+        out_forced = m_forced.integrate(t_span=(0, 1), y0=[1, 1, 1], method='euler', dt=0.01)
+
+        np.testing.assert_allclose(
+            out_forced.state_variables['x'],
+            out_base.state_variables['x'],
+            rtol=1e-10,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration behaviour — post-step state replacement and additive
+# ---------------------------------------------------------------------------
+
+class TestIntegrationPostStep:
+    def test_replacement_post_pins_state_variable_t0(self):
+        """Replacing y post-step should pin it to the forced value at every
+        saved timestep."""
+        pin_value = 5.0
+        model = lorenz.Lorenz63()
+        model.register_forcing('y', pb.Forcing(lambda t: pin_value),
+                               attachment_style='replacement')
+        out = model.integrate(t_span=(0, 2), y0=[1, 1, 1], method='euler', dt=0.01)
+        # t=0 is the initial condition (post-step hasn't fired yet); skip it
+        np.testing.assert_allclose(out.state_variables['y'][1:], pin_value, rtol=1e-10)
+
+    def test_additive_post_shifts_state_t1(self):
+        """Adding a constant post-step should accumulate a drift in the
+        affected variable relative to the unforced run."""
+        m_base = lorenz.Lorenz63()
+        out_base = m_base.integrate(t_span=(0, 2), y0=[1, 1, 1], method='euler', dt=0.01)
+
+        m_forced = lorenz.Lorenz63()
+        m_forced.register_forcing('z', pb.Forcing(lambda t: 0.5),
+                                  attachment_style='additive', timing='post')
+        out_forced = m_forced.integrate(t_span=(0, 2), y0=[1, 1, 1], method='euler', dt=0.01)
+
+        assert not np.allclose(out_forced.state_variables['z'],
+                               out_base.state_variables['z'])
+
+    def test_post_step_adaptive_solver_warns_t2(self):
+        """Post-step forcings with an adaptive solver should emit a UserWarning."""
+        model = lorenz.Lorenz63()
+        model.register_forcing('y', pb.Forcing(lambda t: 0.0),
+                               attachment_style='replacement')
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            model.integrate(t_span=(0, 1), y0=[1, 1, 1], method='RK45')
+        assert any(issubclass(w.category, UserWarning) and 'adaptive' in str(w.message).lower()
+                   for w in caught)

--- a/paleobeasts/tests/test_core_pbmodel_time_axis.py
+++ b/paleobeasts/tests/test_core_pbmodel_time_axis.py
@@ -15,11 +15,7 @@ from paleobeasts.signal_models import lorenz
 
 class TestCorePBModelReframeTimeAxis:
     def test_reframe_time_axis_rk45_t0(self):
-        def func(x):
-            return 0
-
-        forcing = pb.core.Forcing(func)
-        model = lorenz.Lorenz63(forcing=forcing)
+        model = lorenz.Lorenz63()
         output = model.integrate(t_span=(0, 5), y0=[1, 1, 1], method='RK45')
 
         t_eval = np.linspace(0, 5, 51)
@@ -29,11 +25,7 @@ class TestCorePBModelReframeTimeAxis:
         assert set(reframed.dtype.names) == {'x', 'y', 'z'}
 
     def test_reframe_time_axis_euler_t0(self):
-        def func(x):
-            return 0
-
-        forcing = pb.core.Forcing(func)
-        model = lorenz.Lorenz63(forcing=forcing)
+        model = lorenz.Lorenz63()
         output = model.integrate(t_span=(0, 5), y0=[1, 1, 1], method='euler', dt=0.1)
 
         t_eval = np.linspace(0, 5, 26)
@@ -45,7 +37,7 @@ class TestCorePBModelReframeTimeAxis:
 
 class _PostHistoryModel(PBModel):
     def __init__(self):
-        super().__init__(forcing=None, variable_name='post_history', state_variables=['x'],
+        super().__init__(variable_name='post_history', state_variables=['x'],
                          diagnostic_variables=['x_squared'])
 
     uses_post_history = True
@@ -70,7 +62,6 @@ class TestCorePBModelPostHistoryHooks:
 class _ParamContractModel(PBModel):
     def __init__(self, coeff=1.0):
         super().__init__(
-            forcing=None,
             variable_name='param_contract',
             state_variables=['x'],
             diagnostic_variables=[],
@@ -106,7 +97,7 @@ class TestCorePBModelParameterContract:
 
 class _FunctionSwapModel(PBModel):
     def __init__(self):
-        super().__init__(forcing=None, variable_name='function_swap', state_variables=['x'])
+        super().__init__(variable_name='function_swap', state_variables=['x'])
 
     def calc_term(self, value):
         return value + 1

--- a/paleobeasts/tests/test_signal_models_daisyworld.py
+++ b/paleobeasts/tests/test_signal_models_daisyworld.py
@@ -12,7 +12,7 @@ class TestSignalModelsDaisyworldIntegrate:
     @pytest.mark.parametrize('t_span', [(0, 2), (0, 5)])
     @pytest.mark.parametrize('method, dt', [('euler', 0.01), ('RK45', None)])
     def test_integrate_t0(self, t_span, y0, method, dt):
-        model = daisyworld.Daisyworld(forcing=None)
+        model = daisyworld.Daisyworld()
         model.integrate(t_span=t_span, y0=y0, method=method, dt=dt)
 
         assert model.state_variables.dtype.names == ('Aw', 'Ab', 'T')
@@ -23,10 +23,9 @@ class TestSignalModelsDaisyworldIntegrate:
 class TestSignalModelsDaisyworldTimeVaryingParams:
     def test_time_varying_params_match_constants_t0(self):
         model_const = daisyworld.Daisyworld(
-            forcing=None, alpha_w=0.75, alpha_b=0.25, gamma=0.3, L=1.0, C=10.0
+            alpha_w=0.75, alpha_b=0.25, gamma=0.3, L=1.0, C=10.0
         )
         model_tv = daisyworld.Daisyworld(
-            forcing=None,
             alpha_w=lambda t, x, m: 0.75,
             alpha_b=lambda t: 0.25,
             gamma=lambda t, x: 0.3,
@@ -54,8 +53,9 @@ class TestSignalModelsDaisyworldTimeVaryingParams:
 
 class TestSignalModelsDaisyworldForcing:
     def test_luminosity_forcing_changes_temperature_t0(self):
-        forced = daisyworld.Daisyworld(forcing=pb.core.Forcing(lambda t: 0.1))
-        unforced = daisyworld.Daisyworld(forcing=None)
+        forced = daisyworld.Daisyworld()
+        forced.register_forcing('L', pb.core.Forcing(lambda t: 0.1))
+        unforced = daisyworld.Daisyworld()
         t_span = (0, 0.05)
         y0 = [0.2, 0.2, 288.0]
 

--- a/paleobeasts/tests/test_signal_models_damped_spring.py
+++ b/paleobeasts/tests/test_signal_models_damped_spring.py
@@ -11,7 +11,7 @@ class TestSignalModelsDampedSpringIntegrate:
     @pytest.mark.parametrize('y0', [[1.0, 0.0], [0.0, 1.0]])
     @pytest.mark.parametrize('method, dt', [('euler', 0.01), ('RK45', None)])
     def test_integrate_t0(self, y0, method, dt):
-        model = DampedSpring(forcing=None, m=1.0, k=1.0, c=0.1)
+        model = DampedSpring(m=1.0, k=1.0, c=0.1)
         model.integrate(t_span=(0, 10), y0=y0, method=method, dt=dt)
 
         assert model.state_variables.dtype.names == ('x', 'v')
@@ -24,7 +24,7 @@ class TestSignalModelsDampedSpringIntegrate:
 class TestSignalModelsDampedSpringtoPyleo:
     @pytest.mark.parametrize('var_names', ['x', 'v', ['x', 'v']])
     def test_topyleo_t0(self, var_names):
-        model = DampedSpring(forcing=None)
+        model = DampedSpring()
         output = model.integrate(t_span=(0, 5), y0=[1.0, 0.0], method='RK45')
         output.to_pyleo(var_names=var_names)
 
@@ -32,7 +32,7 @@ class TestSignalModelsDampedSpringtoPyleo:
 class TestSignalModelsDampedSpringPhysics:
     def test_undamped_energy_conservation_t0(self):
         """c=0, no forcing: total mechanical energy should be conserved."""
-        model = DampedSpring(forcing=None, m=1.0, k=4.0, c=0.0)
+        model = DampedSpring(m=1.0, k=4.0, c=0.0)
         model.integrate(
             t_span=(0, 20), y0=[1.0, 0.0], method='RK45',
             kwargs={'rtol': 1e-10, 'atol': 1e-12},
@@ -42,7 +42,7 @@ class TestSignalModelsDampedSpringPhysics:
 
     def test_damped_energy_decreases_t1(self):
         """Positive damping must dissipate energy over time."""
-        model = DampedSpring(forcing=None, m=1.0, k=1.0, c=0.5)
+        model = DampedSpring(m=1.0, k=1.0, c=0.5)
         model.integrate(t_span=(0, 20), y0=[1.0, 0.0], method='RK45')
         energy = model.diagnostic_variables['energy']
         assert energy[-1] < energy[0]
@@ -52,7 +52,8 @@ class TestSignalModelsDampedSpringPhysics:
         m, k = 1.0, 4.0
         omega_0 = np.sqrt(k / m)
         forcing = pb.core.Forcing(lambda t: np.cos(omega_0 * t))
-        model = DampedSpring(forcing=forcing, m=m, k=k, c=0.0)
+        model = DampedSpring(m=m, k=k, c=0.0)
+        model.register_forcing('F', forcing)
         model.integrate(t_span=(0, 30), y0=[0.0, 0.0], method='RK45')
 
         x = model.state_variables['x']
@@ -65,7 +66,7 @@ class TestSignalModelsDampedSpringPhysics:
         # c = 2*sqrt(k*m)*2 gives ζ = 2 (overdamped)
         m, k = 1.0, 1.0
         c = 4.0 * np.sqrt(k * m)
-        model = DampedSpring(forcing=None, m=m, k=k, c=c)
+        model = DampedSpring(m=m, k=k, c=c)
         model.integrate(t_span=(0, 20), y0=[1.0, 0.0], method='RK45')
 
         x = model.state_variables['x']
@@ -75,25 +76,24 @@ class TestSignalModelsDampedSpringPhysics:
 
 class TestSignalModelsDampedSpringConvenienceMethods:
     def test_natural_frequency_t0(self):
-        model = DampedSpring(forcing=None, m=2.0, k=8.0, c=0.0)
+        model = DampedSpring(m=2.0, k=8.0, c=0.0)
         assert np.isclose(model.natural_frequency(), np.sqrt(8.0 / 2.0))
 
     def test_natural_period_t1(self):
-        model = DampedSpring(forcing=None, m=1.0, k=4.0, c=0.0)
+        model = DampedSpring(m=1.0, k=4.0, c=0.0)
         assert np.isclose(model.natural_period(), 2.0 * np.pi / 2.0)
 
     def test_damping_ratio_t2(self):
         m, k, c = 1.0, 4.0, 2.0
-        model = DampedSpring(forcing=None, m=m, k=k, c=c)
+        model = DampedSpring(m=m, k=k, c=c)
         expected = c / (2.0 * np.sqrt(k * m))
         assert np.isclose(model.damping_ratio(), expected)
 
 
 class TestSignalModelsDampedSpringTimeVaryingParams:
     def test_time_varying_params_match_constants_t0(self):
-        model_const = DampedSpring(forcing=None, m=1.0, k=2.0, c=0.2)
+        model_const = DampedSpring(m=1.0, k=2.0, c=0.2)
         model_tv = DampedSpring(
-            forcing=None,
             m=lambda t: 1.0,
             k=lambda t, x: 2.0,
             c=lambda t, x, m: 0.2,
@@ -112,11 +112,11 @@ class TestSignalModelsDampedSpringTimeVaryingParams:
 
 class TestSignalModelsDampedSpringInvalidParams:
     def test_nonpositive_mass_raises_t0(self):
-        model = DampedSpring(forcing=None, m=-1.0, k=1.0, c=0.0)
+        model = DampedSpring(m=-1.0, k=1.0, c=0.0)
         with pytest.raises(ValueError, match="m must be > 0"):
             model.integrate(t_span=(0, 1), y0=[1.0, 0.0], method='euler', dt=0.1)
 
     def test_nonpositive_spring_constant_raises_t1(self):
-        model = DampedSpring(forcing=None, m=1.0, k=0.0, c=0.0)
+        model = DampedSpring(m=1.0, k=0.0, c=0.0)
         with pytest.raises(ValueError, match="k must be > 0"):
             model.integrate(t_span=(0, 1), y0=[1.0, 0.0], method='euler', dt=0.1)

--- a/paleobeasts/tests/test_signal_models_ebm.py
+++ b/paleobeasts/tests/test_signal_models_ebm.py
@@ -28,7 +28,8 @@ class TestSignalModelsEBM0DIntegrate:
     def test_integrate_t0(self, t_span, y0, method, OLR, dt):
         '''Test integrate method'''
         forcing = pb.core.Forcing(lambda x: 1)
-        model = ebm.EBM0D(forcing=forcing, OLR=OLR)
+        model = ebm.EBM0D(OLR=OLR)
+        model.register_forcing('S0', forcing)
         model.integrate(t_span=t_span, y0=y0, method=method, dt=dt)
 
 
@@ -46,7 +47,8 @@ class TestSignalModelsEBM0DtoPyleo:
     def test_topyleo_t0(self, method, dt, var_names):
         '''Test to_pyleo method'''
         forcing = pb.core.Forcing(lambda x: 1)
-        model = ebm.EBM0D(forcing=forcing)
+        model = ebm.EBM0D()
+        model.register_forcing('S0', forcing)
         output = model.integrate(t_span=(0, 10), y0=[100], method=method, dt=dt)
         output.to_pyleo(var_names=var_names)
 
@@ -55,12 +57,13 @@ class TestSignalModelsEBM0DTimeVaryingParams:
     def test_time_varying_params_match_constants_t0(self):
         forcing = pb.core.Forcing(lambda t: 1360.0)
 
-        model_const = ebm.EBM0D(forcing=forcing, C=4.0, albedo=0.3)
+        model_const = ebm.EBM0D(C=4.0, albedo=0.3)
+        model_const.register_forcing('S0', forcing)
         model_tv = ebm.EBM0D(
-            forcing=forcing,
             C=lambda t, state, model: 4.0,
             albedo=lambda t, state: 0.3,
         )
+        model_tv.register_forcing('S0', forcing)
 
         t_span = (0, 10)
         output_const = model_const.integrate(t_span=t_span, y0=[280], method='euler', dt=1)
@@ -81,7 +84,8 @@ class TestSignalModelsEBM0DSequenceForcing:
             ],
             label='ebm_sequence',
         )
-        model = ebm.EBM0D(forcing=forcing)
+        model = ebm.EBM0D()
+        model.register_forcing('S0', forcing)
         output = model.integrate(t_span=(0, 10), y0=[280], method='euler', dt=1)
         assert len(output.time) > 1
         assert np.isfinite(output.state_variables['T'][-1])
@@ -90,7 +94,7 @@ class TestSignalModelsEBM0DSequenceForcing:
 class TestSignalModelsEBM1DLatSmoke:
     def test_ebm1dlat_integrates_t0(self):
         '''EBM1DLat is importable, integrates, and produces expected diagnostics.'''
-        model = ebm.EBM1DLat(forcing=None, S0=1365.0)
+        model = ebm.EBM1DLat(S0=1365.0)
         output = model.integrate(t_span=(0, 50), y0=[15.0])
         assert len(output.diagnostic_variables['Tglobal']) == len(output.time)
         assert np.isfinite(output.diagnostic_variables['Tglobal'][-1])

--- a/paleobeasts/tests/test_signal_models_ebm1d_lat.py
+++ b/paleobeasts/tests/test_signal_models_ebm1d_lat.py
@@ -20,7 +20,7 @@ from paleobeasts.signal_models import EBM1DLat
 
 class TestSignalModelsEBM1DLat:
     def test_import_and_equilibrate_t0(self):
-        model = EBM1DLat(forcing=None, S0=1365.0)
+        model = EBM1DLat(S0=1365.0)
         output = model.integrate(t_span=(0, 200), y0=[15.0])
 
         assert len(output.diagnostic_variables['Tglobal']) == len(output.time)
@@ -28,7 +28,7 @@ class TestSignalModelsEBM1DLat:
         assert np.isclose(output.diagnostic_variables['Tglobal'][-1], 15.0, atol=5.0)
 
     def test_cold_state_low_latitude_ice_t0(self):
-        model = EBM1DLat(forcing=None, S0=1200.0)
+        model = EBM1DLat(S0=1200.0)
         output = model.integrate(t_span=(0, 200), y0=[0.0])
 
         assert np.isfinite(output.diagnostic_variables['ice_line_lat'][-1])
@@ -36,7 +36,7 @@ class TestSignalModelsEBM1DLat:
 
     def test_grid_sizes_t0(self):
         for grid_n in (30, 100):
-            model = EBM1DLat(forcing=None, grid_n=grid_n, S0=1365.0)
+            model = EBM1DLat(grid_n=grid_n, S0=1365.0)
             output = model.integrate(t_span=(0, 50), y0=[15.0])
 
             assert len(output.state_variables.dtype.names) == grid_n

--- a/paleobeasts/tests/test_signal_models_enso_recharge.py
+++ b/paleobeasts/tests/test_signal_models_enso_recharge.py
@@ -63,28 +63,12 @@ class TestSignalModelsENSORechargeOscillator:
         got = np.column_stack([model.state_variables["T"], model.state_variables["h"]])
         assert np.allclose(got, x_ref, rtol=1e-6, atol=1e-6)
 
-    def test_external_forcing_replaces_internal_seasonal_term(self):
-        forcing = Forcing(lambda t: 2.5)
-        model = ENSORechargeOscillator(forcing=forcing, mu=0.8, en=0.2, Af=999.0, Pf=6.0)
-
-        dT, dh = model.recharge_components(1.5, [0.1, -0.2])
-
-        mu = 0.8
-        en = 0.2
-        c = 1.0
-        r = 0.25
-        alpha = 0.125
-        b0 = 2.5
-        gamma = 0.75
-        T = 0.1
-        h = -0.2
-        b = b0 * mu
-        R = gamma * b - c
-        expected_dT = R * T + gamma * h - en * (h + b * T) ** 3 + 2.5
-        expected_dh = -r * h - alpha * b * T
-
-        assert np.isclose(dT, expected_dT)
-        assert np.isclose(dh, expected_dh)
+    def test_sst_forcing_matches_analytic_at_quarter_period(self):
+        """_sst_forcing at t=Pf/4 should equal Af (peak of sine)."""
+        Af, Pf = 2.5, 6.0
+        model = ENSORechargeOscillator(mu=0.8, en=0.2, Af=Af, Pf=Pf)
+        t_peak = Pf / 4.0
+        assert np.isclose(model._sst_forcing(t_peak, [0.1, -0.2]), Af)
 
     def test_enso_like_period_t0(self):
         model = ENSORechargeOscillator(mu=0.8, en=3.0, Af=0.0, Pf=6.0)

--- a/paleobeasts/tests/test_signal_models_g24.py
+++ b/paleobeasts/tests/test_signal_models_g24.py
@@ -28,7 +28,8 @@ class TestSignalModelsG24Integrate:
         def func(x):
             return 1
         forcing = pb.core.Forcing(func)
-        model3 = g24.Model3(forcing=forcing)
+        model3 = g24.Model3()
+        model3.register_forcing('insolation', forcing)
         model3.integrate(t_span=t_span,y0=y0,method=method,dt=dt)
 
 class TestSignalModelsG24toPyleo:
@@ -39,7 +40,8 @@ class TestSignalModelsG24toPyleo:
         def func(x):
             return 1
         forcing = pb.core.Forcing(func)
-        model3 = g24.Model3(forcing=forcing)
+        model3 = g24.Model3()
+        model3.register_forcing('insolation', forcing)
         output = model3.integrate(t_span=(0,10),y0=[1,1],method=method,dt=dt)
         output.to_pyleo(var_names=var_names)
 
@@ -48,15 +50,16 @@ class TestSignalModelsG24TimeVaryingParams:
     def test_time_varying_params_match_constants_t0(self):
         forcing = pb.core.Forcing(lambda t: 1.0)
 
-        model_const = g24.Model3(forcing=forcing, f1=-16, f2=16, t1=30, t2=10, vc=1.4)
+        model_const = g24.Model3(f1=-16, f2=16, t1=30, t2=10, vc=1.4)
+        model_const.register_forcing('insolation', forcing)
         model_tv = g24.Model3(
-            forcing=forcing,
             f1=lambda t: -16,
             f2=lambda t, x: 16,
             t1=lambda t, x: 30,
             t2=lambda t, x: 10,
             vc=lambda t, x, m: 1.4,
         )
+        model_tv.register_forcing('insolation', forcing)
 
         t_span = (0, 10)
         y0 = [1, 1]
@@ -72,20 +75,19 @@ class TestSignalModelsG24TimeVaryingParams:
         forcing = pb.core.Forcing(lambda t: 1.0)
 
         model_tv = g24.Model3(
-            forcing=forcing,
             f1=lambda t: -16,
             f2=lambda t, x: 16,
             t1=lambda t, x, m: 30,
             t2=lambda t: 10,
             vc=lambda t, x: 1.4,
         )
+        model_tv.register_forcing('insolation', forcing)
 
         model_tv.integrate(t_span=(0, 10), y0=[1, 1], method='euler', dt=1)
         assert np.isfinite(model_tv.state_variables['v'][-1])
 
     def test_dfdt_attribute_assignment_updates_param_store_t2(self):
-        forcing = pb.core.Forcing(lambda t: 1.0)
-        model3 = g24.Model3(forcing=forcing)
+        model3 = g24.Model3()
         model3.dfdt = lambda t: 123.0
         assert model3.param_values['dfdt'](0.0) == 123.0
         assert model3.calc_dfdt(0.0, [1.0]) == 123.0
@@ -100,6 +102,7 @@ class TestSignalModelsG24SequenceForcing:
             ],
             label='g24_sequence',
         )
-        model3 = g24.Model3(forcing=forcing)
+        model3 = g24.Model3()
+        model3.register_forcing('insolation', forcing)
         model3.integrate(t_span=(0, 10), y0=[1, 1], method='euler', dt=1)
         assert np.isfinite(model3.state_variables['v'][-1])

--- a/paleobeasts/tests/test_signal_models_lorenz63.py
+++ b/paleobeasts/tests/test_signal_models_lorenz63.py
@@ -26,8 +26,7 @@ class TestSignalModelsLorenz63Integrate:
     @pytest.mark.parametrize('method, dt', [('euler', 0.01), ('RK45', None)])
     def test_integrate_t0(self, t_span, y0, method, dt):
         '''Test integrate method'''
-        forcing = pb.core.Forcing(lambda t: 0)
-        model = lorenz.Lorenz63(forcing=forcing)
+        model = lorenz.Lorenz63()
         model.integrate(t_span=t_span, y0=y0, method=method, dt=dt)
 
 
@@ -36,19 +35,15 @@ class TestSignalModelsLorenz63toPyleo:
     @pytest.mark.parametrize('var_names', ['x', 'y', 'z', ['x', 'y'], ['x', 'y', 'z']])
     def test_topyleo_t0(self, method, dt, var_names):
         '''Test to_pyleo method on PBOutput'''
-        forcing = pb.core.Forcing(lambda t: 0)
-        model = lorenz.Lorenz63(forcing=forcing)
+        model = lorenz.Lorenz63()
         output = model.integrate(t_span=(0, 10), y0=[1, 1, 1], method=method, dt=dt)
         output.to_pyleo(var_names=var_names)
 
 
 class TestSignalModelsLorenz63TimeVaryingParams:
     def test_time_varying_params_match_constants_t0(self):
-        forcing = pb.core.Forcing(lambda t: 0.0)
-
-        model_const = lorenz.Lorenz63(forcing=forcing, sigma=10.0, rho=28.0, beta=8 / 3)
+        model_const = lorenz.Lorenz63(sigma=10.0, rho=28.0, beta=8 / 3)
         model_tv = lorenz.Lorenz63(
-            forcing=forcing,
             sigma=lambda t, x, m: 10.0,
             rho=lambda t: 28.0,
             beta=lambda t, x: 8 / 3,

--- a/paleobeasts/tests/test_signal_models_lorenz96.py
+++ b/paleobeasts/tests/test_signal_models_lorenz96.py
@@ -13,31 +13,31 @@ from paleobeasts.signal_models import lorenz
 
 class TestSignalModelsLorenz96Integrate:
     def test_integrate_rk45_t0(self):
-        model = lorenz.Lorenz96(forcing=None, n=5, F=8.0)
+        model = lorenz.Lorenz96(n=5, F=8.0)
         model.integrate(t_span=(0, 5), y0=[1, 1, 1, 1, 1], method='RK45')
 
     def test_integrate_euler_t0(self):
-        model = lorenz.Lorenz96(forcing=None, n=5, F=8.0)
+        model = lorenz.Lorenz96(n=5, F=8.0)
         model.integrate(t_span=(0, 5), y0=[1, 1, 1, 1, 1], method='euler', dt=0.01)
 
     def test_integrate_rk4_t0(self):
         '''Two-scale system integrated with rk4; Lorenz96TwoScale replaced by Lorenz96(J>0).'''
-        model = lorenz.Lorenz96(forcing=None, n=4, J=2, F=10.0, h=1.0, b=10.0, c=10.0, exact_rhs=True)
+        model = lorenz.Lorenz96(n=4, J=2, F=10.0, h=1.0, b=10.0, c=10.0, exact_rhs=True)
         y0 = np.zeros(4 + 4 * 2)
         model.integrate(t_span=(0, 1.0), y0=y0, method='rk4', dt=0.01, kwargs={'si': 0.05})
 
 
 class TestSignalModelsLorenz96toPyleo:
     def test_topyleo_t0(self):
-        model = lorenz.Lorenz96(forcing=None, n=5, F=8.0)
+        model = lorenz.Lorenz96(n=5, F=8.0)
         output = model.integrate(t_span=(0, 5), y0=[1, 1, 1, 1, 1], method='RK45')
         output.to_pyleo(var_names=['x0', 'x1'])
 
 
 class TestSignalModelsLorenz96TimeVaryingParams:
     def test_time_varying_param_matches_constant_t0(self):
-        model_const = lorenz.Lorenz96(forcing=None, n=5, F=8.0)
-        model_tv = lorenz.Lorenz96(forcing=None, n=5, F=lambda t, x, m: 8.0)
+        model_const = lorenz.Lorenz96(n=5, F=8.0)
+        model_tv = lorenz.Lorenz96(n=5, F=lambda t, x, m: 8.0)
 
         t_span = (0, 0.05)
         y0 = [1, 1, 1, 1, 1]
@@ -55,7 +55,7 @@ class TestSignalModelsLorenz96TwoScale:
         '''Two-scale system using Lorenz96(J>0); Lorenz96TwoScale no longer exists.'''
         K = 5
         J = 2
-        model = lorenz.Lorenz96(forcing=None, n=K, J=J, F=10.0, h=1.0, b=10.0, c=10.0)
+        model = lorenz.Lorenz96(n=K, J=J, F=10.0, h=1.0, b=10.0, c=10.0)
         y0 = np.zeros(K + K * J)
         model.integrate(t_span=(0, 0.05), y0=y0, method='euler', dt=0.01)
 

--- a/paleobeasts/tests/test_signal_models_pendulum.py
+++ b/paleobeasts/tests/test_signal_models_pendulum.py
@@ -15,7 +15,7 @@ class TestSignalModelsSimplePendulumIntegrate:
     @pytest.mark.parametrize('y0', [[0.1, 0.0], [0.5, 0.0]])
     @pytest.mark.parametrize('method, dt', [('euler', 0.01), ('RK45', None)])
     def test_integrate_t0(self, y0, method, dt):
-        model = SimplePendulum(forcing=None, L=1.0, g=9.81, damping=0.0)
+        model = SimplePendulum(L=1.0, g=9.81, damping=0.0)
         model.integrate(t_span=(0, 5), y0=y0, method=method, dt=dt)
 
         assert model.state_variables.dtype.names == ('theta', 'omega')
@@ -27,7 +27,7 @@ class TestSignalModelsSimplePendulumIntegrate:
 class TestSignalModelsSimplePendulumsotoPyleo:
     @pytest.mark.parametrize('var_names', ['theta', 'omega', ['theta', 'omega']])
     def test_topyleo_t0(self, var_names):
-        model = SimplePendulum(forcing=None)
+        model = SimplePendulum()
         output = model.integrate(t_span=(0, 5), y0=[0.1, 0.0], method='RK45')
         output.to_pyleo(var_names=var_names)
 
@@ -36,7 +36,7 @@ class TestSignalModelsSimplePendulumPhysics:
     def test_small_angle_period_t0(self):
         """Small-amplitude oscillations should match the linear period 2π/ω₀."""
         L, g = 1.0, 9.81
-        model = SimplePendulum(forcing=None, L=L, g=g, damping=0.0)
+        model = SimplePendulum(L=L, g=g, damping=0.0)
         T0 = 2.0 * np.pi * np.sqrt(L / g)
 
         model.integrate(
@@ -55,7 +55,7 @@ class TestSignalModelsSimplePendulumPhysics:
 
     def test_undamped_energy_conservation_t1(self):
         """Zero damping, no forcing: mechanical energy must be conserved."""
-        model = SimplePendulum(forcing=None, L=1.0, g=9.81, damping=0.0)
+        model = SimplePendulum(L=1.0, g=9.81, damping=0.0)
         model.integrate(
             t_span=(0, 20), y0=[0.3, 0.0], method='RK45',
             kwargs={'rtol': 1e-10, 'atol': 1e-12},
@@ -65,7 +65,7 @@ class TestSignalModelsSimplePendulumPhysics:
 
     def test_damped_energy_decreases_t2(self):
         """Positive damping must reduce energy over time."""
-        model = SimplePendulum(forcing=None, L=1.0, g=9.81, damping=0.5)
+        model = SimplePendulum(L=1.0, g=9.81, damping=0.5)
         model.integrate(t_span=(0, 20), y0=[0.5, 0.0], method='RK45')
         energy = model.diagnostic_variables['energy']
         assert energy[-1] < energy[0]
@@ -73,7 +73,7 @@ class TestSignalModelsSimplePendulumPhysics:
     def test_omega_0_diagnostic_matches_helper_t3(self):
         """omega_0 diagnostic should equal natural_frequency() at every step."""
         L, g = 2.0, 9.81
-        model = SimplePendulum(forcing=None, L=L, g=g, damping=0.0)
+        model = SimplePendulum(L=L, g=g, damping=0.0)
         model.integrate(t_span=(0, 5), y0=[0.1, 0.0], method='RK45')
         expected = np.sqrt(g / L)
         assert np.allclose(model.diagnostic_variables['omega_0'], expected)
@@ -81,28 +81,28 @@ class TestSignalModelsSimplePendulumPhysics:
 
 class TestSignalModelsSimplePendulumConvenienceMethods:
     def test_natural_frequency_t0(self):
-        model = SimplePendulum(forcing=None, L=2.0, g=9.81)
+        model = SimplePendulum(L=2.0, g=9.81)
         assert np.isclose(model.natural_frequency(), np.sqrt(9.81 / 2.0))
 
     def test_natural_period_t1(self):
-        model = SimplePendulum(forcing=None, L=1.0, g=9.81)
+        model = SimplePendulum(L=1.0, g=9.81)
         assert np.isclose(model.natural_period(), 2.0 * np.pi / np.sqrt(9.81))
 
     def test_damping_ratio_t2(self):
         L, g, lam = 1.0, 9.81, 0.5
-        model = SimplePendulum(forcing=None, L=L, g=g, damping=lam)
+        model = SimplePendulum(L=L, g=g, damping=lam)
         expected = lam / (2.0 * np.sqrt(g / L))
         assert np.isclose(model.damping_ratio(), expected)
 
 
 class TestSignalModelsSimplePendulumInvalidParams:
     def test_nonpositive_L_raises_t0(self):
-        model = SimplePendulum(forcing=None, L=-1.0, g=9.81)
+        model = SimplePendulum(L=-1.0, g=9.81)
         with pytest.raises(ValueError, match="L must be > 0"):
             model.integrate(t_span=(0, 1), y0=[0.1, 0.0], method='euler', dt=0.01)
 
     def test_nonpositive_g_raises_t1(self):
-        model = SimplePendulum(forcing=None, L=1.0, g=0.0)
+        model = SimplePendulum(L=1.0, g=0.0)
         with pytest.raises(ValueError, match="g must be > 0"):
             model.integrate(t_span=(0, 1), y0=[0.1, 0.0], method='euler', dt=0.01)
 
@@ -114,29 +114,28 @@ class TestSignalModelsSimplePendulumInvalidParams:
 class TestSignalModelsDrivenPendulumIntegrate:
     @pytest.mark.parametrize('A, dt', [(0.5, 0.01), (1.2, 0.01)])
     def test_integrate_t0(self, A, dt):
-        model = DrivenPendulum(forcing=None, q=0.5, A=A, Omega=2.0 / 3.0)
+        model = DrivenPendulum(q=0.5, A=A, Omega=2.0 / 3.0)
         model.integrate(t_span=(0, 20), y0=[0.2, 0.0], method='euler', dt=dt)
 
         assert model.state_variables.dtype.names == ('theta', 'omega')
         assert 'energy' in model.diagnostic_variables
         assert 'drive' in model.diagnostic_variables
 
-    def test_forcing_overrides_cosine_drive_t1(self):
-        """Providing a Forcing object should replace the built-in cosine drive."""
-        const_drive = pb.core.Forcing(lambda t: 0.5)
-        model_forced = DrivenPendulum(forcing=const_drive, q=0.5)
-        model_forced.integrate(t_span=(0, 5), y0=[0.0, 0.0], method='RK45')
+    def test_zero_amplitude_gives_zero_drive_t1(self):
+        """A=0 produces zero drive at every step."""
+        model = DrivenPendulum(q=0.5, A=0.0)
+        model.integrate(t_span=(0, 5), y0=[0.0, 0.0], method='RK45')
 
-        drive = model_forced.diagnostic_variables['drive']
-        assert np.allclose(drive, 0.5)
+        drive = model.diagnostic_variables['drive']
+        assert np.allclose(drive, 0.0)
 
     def test_driving_period_helper_t2(self):
         Omega = 2.0 / 3.0
-        model = DrivenPendulum(forcing=None, Omega=Omega)
+        model = DrivenPendulum(Omega=Omega)
         assert np.isclose(model.driving_period(), 2.0 * np.pi / Omega)
 
     def test_topyleo_t3(self):
-        model = DrivenPendulum(forcing=None)
+        model = DrivenPendulum()
         output = model.integrate(t_span=(0, 10), y0=[0.2, 0.0], method='RK45')
         output.to_pyleo(var_names='theta')
 
@@ -147,7 +146,7 @@ class TestSignalModelsDrivenPendulumIntegrate:
 
 class TestSignalModelsDoublePendulumIntegrate:
     def test_integrate_t0(self):
-        model = DoublePendulum(forcing=None)
+        model = DoublePendulum()
         model.integrate(t_span=(0, 5), y0=[np.pi / 2, 0.0, np.pi / 4, 0.0],
                         method='RK45')
 
@@ -158,7 +157,7 @@ class TestSignalModelsDoublePendulumIntegrate:
 
     def test_energy_conservation_t1(self):
         """No damping: total energy should be conserved to solver tolerance."""
-        model = DoublePendulum(forcing=None, d1=0.0, d2=0.0)
+        model = DoublePendulum(d1=0.0, d2=0.0)
         model.integrate(
             t_span=(0, 10), y0=[np.pi / 4, 0.0, np.pi / 4, 0.0],
             method='RK45', kwargs={'rtol': 1e-10, 'atol': 1e-12},
@@ -167,7 +166,7 @@ class TestSignalModelsDoublePendulumIntegrate:
         assert np.max(np.abs(energy - energy[0])) < 1e-4
 
     def test_damping_reduces_energy_t2(self):
-        model = DoublePendulum(forcing=None, d1=0.1, d2=0.1)
+        model = DoublePendulum(d1=0.1, d2=0.1)
         model.integrate(t_span=(0, 20), y0=[np.pi / 4, 0.0, np.pi / 4, 0.0],
                         method='RK45')
         energy = model.diagnostic_variables['energy']
@@ -175,7 +174,7 @@ class TestSignalModelsDoublePendulumIntegrate:
 
     def test_cartesian_positions_t3(self):
         """cartesian_positions() should return four finite arrays of the right length."""
-        model = DoublePendulum(forcing=None)
+        model = DoublePendulum()
         model.integrate(t_span=(0, 5), y0=[0.5, 0.0, 0.5, 0.0], method='RK45')
         x1, y1, x2, y2 = model.cartesian_positions()
 
@@ -185,7 +184,7 @@ class TestSignalModelsDoublePendulumIntegrate:
             assert np.all(np.isfinite(arr))
 
     def test_topyleo_t4(self):
-        model = DoublePendulum(forcing=None)
+        model = DoublePendulum()
         output = model.integrate(t_span=(0, 5), y0=[0.5, 0.0, 0.5, 0.0],
                                  method='RK45')
         output.to_pyleo(var_names=['theta1', 'theta2'])

--- a/paleobeasts/tests/test_signal_models_roessler.py
+++ b/paleobeasts/tests/test_signal_models_roessler.py
@@ -6,14 +6,14 @@ from paleobeasts.signal_models import Roessler
 
 class TestSignalModelsRoessler:
     def test_import_and_integrate_t0(self):
-        model = Roessler(forcing=None, a=0.2, b=0.2, c=5.7)
+        model = Roessler(a=0.2, b=0.2, c=5.7)
         model.integrate(t_span=(0, 100), y0=[1, 1, 1])
 
         assert model.state_variables.dtype.names == ('x', 'y', 'z')
         assert len(model.time) == len(model.state_variables)
 
     def test_bounded_attractor_t0(self):
-        model = Roessler(forcing=None, a=0.2, b=0.2, c=5.7)
+        model = Roessler(a=0.2, b=0.2, c=5.7)
         model.integrate(t_span=(0, 200), y0=[1, 1, 1])
 
         assert np.max(np.abs(model.state_variables['x'])) < 30
@@ -22,7 +22,7 @@ class TestSignalModelsRoessler:
         const_a = pb.core.Forcing(lambda t: 0.2)
         const_b = pb.core.Forcing(lambda t: 0.2)
         const_c = pb.core.Forcing(lambda t: 5.7)
-        model = Roessler(forcing=None, a=const_a, b=const_b, c=const_c)
+        model = Roessler(a=const_a, b=const_b, c=const_c)
 
         model.integrate(t_span=(0, 10), y0=[1, 1, 1], method='euler', dt=0.01)
 

--- a/paleobeasts/tests/test_signal_models_stocker2003.py
+++ b/paleobeasts/tests/test_signal_models_stocker2003.py
@@ -12,7 +12,8 @@ class TestSignalModelsStocker2003Integrate:
         north = np.sin(2.0 * np.pi * time / 1200.0)
         forcing = pb.Forcing(data=north, time=time, interpolation="linear")
 
-        model = Stocker2003BipolarSeesaw(forcing=forcing, tau=1000.0, beta=-1.0)
+        model = Stocker2003BipolarSeesaw(tau=1000.0, beta=-1.0)
+        model.register_forcing('Tn', forcing)
         model.integrate(t_span=(0, 4000), y0=[0.0], method="euler", dt=10.0)
 
         assert model.state_variables.dtype.names == ("Ts",)
@@ -21,12 +22,11 @@ class TestSignalModelsStocker2003Integrate:
         assert np.all(np.isfinite(model.diagnostic_variables["Tn"]))
 
     def test_sign_sanity_t0(self):
-        forcing = pb.Forcing(lambda t: 1.0)
-        model = Stocker2003BipolarSeesaw(forcing=forcing, tau=1000.0, beta=-1.0)
+        model = Stocker2003BipolarSeesaw(tau=1000.0, beta=-1.0, Tn=1.0)
         dTs = model.dydt(0.0, np.array([0.0]))[0]
         assert dTs < 0.0
 
     def test_Tn_param_fallback_t0(self):
-        model = Stocker2003BipolarSeesaw(forcing=None, Tn=1.5)
+        model = Stocker2003BipolarSeesaw(Tn=1.5)
         dTs = model.dydt(0.0, np.array([0.0]))[0]
         assert np.isclose(dTs, (-1.0 * 1.5 - 0.0) / 1000.0)

--- a/paleobeasts/tests/test_signal_models_stommel.py
+++ b/paleobeasts/tests/test_signal_models_stommel.py
@@ -12,7 +12,7 @@ class TestSignalModelsStommelIntegrate:
     @pytest.mark.parametrize('t_span', [(0, 2), (0, 5)])
     @pytest.mark.parametrize('method, dt', [('euler', 0.01), ('RK45', None)])
     def test_integrate_t0(self, t_span, y0, method, dt):
-        model = stommel.Stommel(forcing=None)
+        model = stommel.Stommel()
         model.integrate(t_span=t_span, y0=y0, method=method, dt=dt)
         assert model.state_variables.dtype.names == ('T', 'S')
         assert 'q' in model.diagnostic_variables
@@ -20,10 +20,7 @@ class TestSignalModelsStommelIntegrate:
 
 class TestSignalModelsStommelTimeVaryingParams:
     def test_time_varying_params_match_constants_t0(self):
-        forcing = pb.core.Forcing(lambda t: 0.0)
-
         model_const = stommel.Stommel(
-            forcing=forcing,
             alpha=1.0,
             beta=1.0,
             k=1.0,
@@ -34,7 +31,6 @@ class TestSignalModelsStommelTimeVaryingParams:
             S_star=0.0,
         )
         model_tv = stommel.Stommel(
-            forcing=forcing,
             alpha=lambda t, x, m: 1.0,
             beta=lambda t: 1.0,
             k=lambda t, x: 1.0,
@@ -58,8 +54,9 @@ class TestSignalModelsStommelTimeVaryingParams:
 
 class TestSignalModelsStommelForcing:
     def test_scalar_forcing_affects_salinity_tendency_t0(self):
-        forced = stommel.Stommel(forcing=pb.core.Forcing(lambda t: 0.1), E=0.0)
-        unforced = stommel.Stommel(forcing=None, E=0.0)
+        forced = stommel.Stommel(E=0.0)
+        forced.register_forcing('S', pb.core.Forcing(lambda t: 0.1), attachment_style='additive', timing='pre')
+        unforced = stommel.Stommel(E=0.0)
         t_span = (0, 0.05)
         y0 = [1.0, 0.1]
 
@@ -78,6 +75,7 @@ class TestSignalModelsStommelSequenceForcing:
             ],
             label='stommel_sequence',
         )
-        model = stommel.Stommel(forcing=forcing, E=0.0)
+        model = stommel.Stommel(E=0.0)
+        model.register_forcing('S', forcing, attachment_style='additive', timing='pre')
         model.integrate(t_span=(0, 0.05), y0=[1.0, 0.1], method='euler', dt=0.01)
         assert np.isfinite(model.state_variables['S'][-1])

--- a/paleobeasts/tests/test_signal_models_two_box_carbon.py
+++ b/paleobeasts/tests/test_signal_models_two_box_carbon.py
@@ -6,7 +6,7 @@ from paleobeasts.signal_models import BoxModelSpec, TwoBoxCarbon
 
 class TestSignalModelsTwoBoxCarbon:
     def test_import_and_integrate_t0(self):
-        model = TwoBoxCarbon(forcing=None, k=0.2, R=0.0, l_s=0.0)
+        model = TwoBoxCarbon(k=0.2, R=0.0, l_s=0.0)
         model.integrate(t_span=(0, 10), y0=[100.0, 50.0])
 
         assert model.state_variables.dtype.names == ("A", "S")
@@ -14,14 +14,14 @@ class TestSignalModelsTwoBoxCarbon:
         assert np.all(np.isfinite(model.diagnostic_variables["net_flux"]))
 
     def test_closed_system_conserves_mass_t0(self):
-        model = TwoBoxCarbon(forcing=None, k=0.2, R=0.0, l_s=0.0, V_atm=1.0, V_surf=50.0)
+        model = TwoBoxCarbon(k=0.2, R=0.0, l_s=0.0, V_atm=1.0, V_surf=50.0)
         model.integrate(t_span=(0, 100), y0=[100.0, 200.0], method="RK45")
 
         total = model.state_variables["A"] + model.state_variables["S"]
         assert np.max(np.abs(total - total[0])) < 1e-8
 
     def test_forced_system_reaches_steady_state_t0(self):
-        model = TwoBoxCarbon(forcing=None, k=0.2, R=1.0, l_s=0.05)
+        model = TwoBoxCarbon(k=0.2, R=1.0, l_s=0.05)
         model.integrate(t_span=(0, 100), y0=[0.0, 0.0], method="RK45")
 
         A_eq = 1.0 / 0.05
@@ -70,7 +70,8 @@ class TestSignalModelsGenericBoxModel:
         })
 
         north = pb.Forcing(lambda t: 1.0)
-        model = spec.make_boxmodel(forcing=north)
+        model = spec.make_boxmodel()
+        model.register_forcing('Tn', north)
         model.integrate(t_span=(0, 100), y0=[0.0], method="RK45")
 
         assert model.state_variables.dtype.names == ("Ts",)

--- a/paleobeasts/utils/solver.py
+++ b/paleobeasts/utils/solver.py
@@ -207,7 +207,7 @@ def build_state_from_history(time, history, state_variables_names):
     return history
 
 
-def rk4_method(f, t_span, y0, dt, si=None, args=()):
+def rk4_method(f, t_span, y0, dt, si=None, args=(), post_step=None):
     """Fixed-step 4th-order Runge-Kutta integrator.
 
     Parameters
@@ -226,6 +226,10 @@ def rk4_method(f, t_span, y0, dt, si=None, args=()):
         (every step is saved).
     args : tuple
         Extra positional arguments forwarded to ``f``.
+    post_step : callable or None
+        Optional hook called after each accepted sub-step with signature
+        ``post_step(t, y) -> y``.  The returned array replaces the current
+        state, allowing post-step corrections (e.g. state nudging).
 
     Returns
     -------
@@ -272,13 +276,15 @@ def rk4_method(f, t_span, y0, dt, si=None, args=()):
             k3 = np.asarray(f(t_curr + 0.5 * dt, y + 0.5 * dt * k2, *args), dtype=float)
             k4 = np.asarray(f(t_curr + dt, y + dt * k3, *args), dtype=float)
             y = y + (dt / 6.0) * (k1 + 2.0 * k2 + 2.0 * k3 + k4)
+            if post_step is not None:
+                y = np.asarray(post_step(t_curr + dt, y), dtype=float)
         history[step + 1] = y
         times[step + 1] = t0 + (step + 1) * si
 
     return Solution(times, history)
 
 
-def euler_method(f, t_span, y0, dt, args=()):
+def euler_method(f, t_span, y0, dt, args=(), post_step=None):
     """Fixed-step forward Euler integrator.
 
     Parameters
@@ -293,6 +299,10 @@ def euler_method(f, t_span, y0, dt, args=()):
         Fixed timestep.
     args : tuple
         Extra positional arguments forwarded to ``f``.
+    post_step : callable or None
+        Optional hook called after each accepted step with signature
+        ``post_step(t, y) -> y``.  The returned array replaces the current
+        state, allowing post-step corrections (e.g. state nudging).
 
     Returns
     -------
@@ -312,11 +322,13 @@ def euler_method(f, t_span, y0, dt, args=()):
     for i in range(1, n_steps):
         dy = f(t[i - 1], y[i - 1], *args)
         y[i] = y[i - 1] + np.multiply(dy, dt)
+        if post_step is not None:
+            y[i] = np.asarray(post_step(t[i], y[i]), dtype=float)
 
     return Solution(t, y)
 
 
-def euler_maruyama_method(f, t_span, y0, dt, noise_func=None, rng=None, args=()):
+def euler_maruyama_method(f, t_span, y0, dt, noise_func=None, rng=None, args=(), post_step=None):
     """Fixed-step Euler-Maruyama integrator for stochastic differential equations.
 
     Solves:
@@ -344,6 +356,10 @@ def euler_maruyama_method(f, t_span, y0, dt, noise_func=None, rng=None, args=())
         created if ``None``.
     args : tuple
         Extra positional arguments forwarded to ``f``.
+    post_step : callable or None
+        Optional hook called after each accepted step with signature
+        ``post_step(t, y) -> y``.  The returned array replaces the current
+        state, allowing post-step corrections (e.g. state nudging).
 
     Returns
     -------
@@ -381,5 +397,7 @@ def euler_maruyama_method(f, t_span, y0, dt, noise_func=None, rng=None, args=())
 
         dW = rng.normal(0.0, 1.0, size=len(y_prev)) * sqrt_dt
         y[i] = y_prev + dy * dt + diffusion * dW
+        if post_step is not None:
+            y[i] = np.asarray(post_step(t[i], y[i]), dtype=float)
 
     return Solution(t, y)


### PR DESCRIPTION
This pull request introduces a comprehensive and flexible framework for registering and applying external forcings to model parameters and state variables in the `PBModel` class. The changes deprecate the old single-forcing approach in favor of a multi-forcing system, allowing for more complex and physically meaningful model configurations. The update also ensures that forcings are applied at the correct stage of the integration process and are compatible with both fixed-step and adaptive solvers.

The most important changes are:

**Forcing Registration and Specification**

* Added the `ForcingSpec` dataclass in `forcing.py` to encapsulate the details of a single forcing attachment, including validation of attachment style and timing, and a unified evaluation interface. (`[paleobeasts/core/forcing.pyR528-R593](diffhunk://#diff-93cb2c0865be2a23c8e2932020d00deb054d30815882f12fdfd1583a52e6ffdaR528-R593)`)
* Introduced the `register_forcing`, `get_forcings`, and `clear_forcings` methods on `PBModel` to allow attaching, querying, and removing multiple forcings on any parameter or state variable, with explicit rules for attachment style and timing. (`[paleobeasts/core/pbmodel.pyR252-R481](diffhunk://#diff-6703a572d8f91eda9906d398c44d2e623341cf856e29a0c9cd0f18531a381aceR252-R481)`)

**Forcing Application Logic**

* Implemented `_build_forced_dydt` and `_build_post_step` helper methods to apply pre-step and post-step forcings, respectively, ensuring correct modification of parameters and/or state variables during integration. (`[paleobeasts/core/pbmodel.pyR252-R481](diffhunk://#diff-6703a572d8f91eda9906d398c44d2e623341cf856e29a0c9cd0f18531a381aceR252-R481)`)
* Updated the `integrate` method to automatically wrap the system ODEs and post-step callbacks with the registered forcings, and to warn the user if post-step forcings are ignored due to the use of adaptive solvers. (`[paleobeasts/core/pbmodel.pyR567-R586](diffhunk://#diff-6703a572d8f91eda9906d398c44d2e623341cf856e29a0c9cd0f18531a381aceR567-R586)`)

**API and Internal Refactoring**

* Removed the legacy single-forcing interface and associated arguments from `PBModel` and `GenericBoxModel`, updating construction and copying logic to support the new multi-forcing system. (`[[1]](diffhunk://#diff-6703a572d8f91eda9906d398c44d2e623341cf856e29a0c9cd0f18531a381aceR11-R49)`, `[[2]](diffhunk://#diff-6703a572d8f91eda9906d398c44d2e623341cf856e29a0c9cd0f18531a381aceL76-R100)`, `[[3]](diffhunk://#diff-6703a572d8f91eda9906d398c44d2e623341cf856e29a0c9cd0f18531a381aceL145-L157)`, `[[4]](diffhunk://#diff-3475524326dced6edf8e5077bc6efd000371c5653151688e7fc5f6b4370a57cfL378-R388)`, `[[5]](diffhunk://#diff-3475524326dced6edf8e5077bc6efd000371c5653151688e7fc5f6b4370a57cfL405-L422)`)
* Ensured that `ForcingSpec` is exported in the public API. (`[paleobeasts/core/forcing.pyR602](diffhunk://#diff-93cb2c0865be2a23c8e2932020d00deb054d30815882f12fdfd1583a52e6ffdaR602)`)

These changes make the model codebase more robust and extensible, supporting advanced use cases such as multiple concurrent forcings and precise control over their application.