### PR TITLE
binder access

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,0 +1,19 @@
+name: cc_env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - seaborn
+  - scikit-learn
+  - requests
+  - statsmodels
+  - jupyterlab
+  - ipykernel
+  - pip
+  - pip:
+    - setuptools
+    - spectrum
+    - fitter
+    - git+https://github.com/LinkedEarth/Pyleoclim_util.git
+    - pandas>=2.0.0
+    - '.'

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -99,7 +99,7 @@ website:
           contents:
             - section: Energy Balance Models
               contents:
-                - text: 0D
+                - text: "0D"
                   href: notebooks/model_demos/ebm0d.ipynb
                 - text: "1D (latitude)"
                   href: notebooks/model_demos/ebm1d_lat.ipynb
@@ -115,7 +115,7 @@ website:
                   href: notebooks/model_demos/enso_recharge.ipynb
                 - text: "Ganopolski 2024, Model 3"
                   href: notebooks/model_demos/g24.ipynb
-                - text: Stommel
+                - text: "Stommel"
                   href: notebooks/model_demos/stommel.ipynb
             - section: Attractors
               contents:

--- a/docs/scripts/sync_notebooks.py
+++ b/docs/scripts/sync_notebooks.py
@@ -76,10 +76,27 @@ def _parse_markdown_frontmatter(source: list[str]) -> dict | None:
     return fields
 
 
-def _build_raw_frontmatter_cell(fields: dict, original_cell: dict) -> dict:
-    """Build a raw YAML front-matter cell from parsed fields."""
-    # Values that are Quarto keywords and must not be quoted
+GITHUB_REPO = "LinkedEarth/ClimateCritters"
+GITHUB_BRANCH = "main"
+
+
+def _build_raw_frontmatter_cell(fields: dict, original_cell: dict, nb_repo_path: str) -> dict:
+    """Build a raw YAML front-matter cell from parsed fields.
+
+    nb_repo_path: path of the source notebook relative to the repo root,
+                  e.g. 'notebooks/model_demos/stommel.ipynb'. Used to build
+                  the binder and download URLs injected as other-links.
+    """
     UNQUOTED = {"last-modified", "today", "now"}
+
+    binder_url = (
+        f"https://mybinder.org/v2/gh/{GITHUB_REPO}/HEAD"
+        f"?labpath={nb_repo_path}"
+    )
+    download_url = (
+        f"https://raw.githubusercontent.com/{GITHUB_REPO}"
+        f"/{GITHUB_BRANCH}/{nb_repo_path}"
+    )
 
     lines = ["---\n"]
     for key in ("title", "author", "date"):
@@ -93,6 +110,13 @@ def _build_raw_frontmatter_cell(fields: dict, original_cell: dict) -> dict:
         lines.append(f"abstract: >\n  {fields['abstract']}\n")
     if "keywords" in fields:
         lines.append(f"keywords: {fields['keywords']}\n")
+    lines.append(f'other-links:\n')
+    lines.append(f'  - text: "Launch on Binder"\n')
+    lines.append(f'    href: "{binder_url}"\n')
+    lines.append(f'    icon: rocket-takeoff\n')
+    lines.append(f'  - text: "Download notebook"\n')
+    lines.append(f'    href: "{download_url}"\n')
+    lines.append(f'    icon: download\n')
     lines.append("---")
 
     new_cell = copy.deepcopy(original_cell)
@@ -102,7 +126,7 @@ def _build_raw_frontmatter_cell(fields: dict, original_cell: dict) -> dict:
     return new_cell
 
 
-def _convert_notebook(nb: dict) -> tuple[dict, bool]:
+def _convert_notebook(nb: dict, nb_repo_path: str) -> tuple[dict, bool]:
     """Return (notebook, was_converted). Converts markdown metadata cell if present."""
     if not nb["cells"]:
         return nb, False
@@ -114,7 +138,7 @@ def _convert_notebook(nb: dict) -> tuple[dict, bool]:
         return nb, False
 
     nb = copy.deepcopy(nb)
-    nb["cells"][0] = _build_raw_frontmatter_cell(fields, first)
+    nb["cells"][0] = _build_raw_frontmatter_cell(fields, first, nb_repo_path)
     return nb, True
 
 
@@ -132,7 +156,8 @@ def sync():
             if not dst.exists() or nb_path.stat().st_mtime > dst.stat().st_mtime:
                 if nb_path.suffix == ".ipynb":
                     nb = json.loads(nb_path.read_text(encoding="utf-8"))
-                    nb, converted = _convert_notebook(nb)
+                    nb_repo_path = nb_path.relative_to(REPO_ROOT).as_posix()
+                    nb, converted = _convert_notebook(nb, nb_repo_path)
                     dst.write_text(json.dumps(nb, indent=1, ensure_ascii=False), encoding="utf-8")
                     tag = " (front matter converted)" if converted else ""
                     print(f"  synced {nb_path.relative_to(REPO_ROOT)} → docs/notebooks/{subdir}/{nb_path.name}{tag}")


### PR DESCRIPTION
This pull request introduces improvements to the documentation build process and environment setup. The most significant changes are the addition of a reproducible conda environment for Binder, and enhancements to the notebook synchronization script to automatically inject Binder launch and download links into notebook front matter. There are also minor formatting updates to the navigation menu.

**Documentation and Environment Improvements:**

* Added a new `.binder/environment.yml` file specifying all dependencies required for running notebooks on Binder, improving reproducibility and ease of use.

**Notebook Synchronization Enhancements:**

* Updated `docs/scripts/sync_notebooks.py` to inject "Launch on Binder" and "Download notebook" links into the front matter of each notebook, making it easier for users to access notebooks interactively or download them directly. [[1]](diffhunk://#diff-111b38eee46dd92cbba0e0f17e6a64d35dff3d0254ecc3ca703e5e542e9061a2L79-R100) [[2]](diffhunk://#diff-111b38eee46dd92cbba0e0f17e6a64d35dff3d0254ecc3ca703e5e542e9061a2R113-R119)
* Modified the notebook conversion logic to pass the notebook's repository path, enabling correct URL generation for the injected links. [[1]](diffhunk://#diff-111b38eee46dd92cbba0e0f17e6a64d35dff3d0254ecc3ca703e5e542e9061a2L105-R129) [[2]](diffhunk://#diff-111b38eee46dd92cbba0e0f17e6a64d35dff3d0254ecc3ca703e5e542e9061a2L117-R141) [[3]](diffhunk://#diff-111b38eee46dd92cbba0e0f17e6a64d35dff3d0254ecc3ca703e5e542e9061a2L135-R160)

**Documentation Navigation Formatting:**

* Standardized the text fields for certain navigation items in `docs/_quarto.yml` by quoting them, ensuring consistent rendering in the documentation sidebar. [[1]](diffhunk://#diff-3f031d554ecb9bfd2f5476e72e2b804060b60a37eaa6a94610ffde2e7eaa8d45L102-R102) [[2]](diffhunk://#diff-3f031d554ecb9bfd2f5476e72e2b804060b60a37eaa6a94610ffde2e7eaa8d45L118-R118)